### PR TITLE
Use Mix.Project.config instead of Mix.project

### DIFF
--- a/lib/dialyzer.ex
+++ b/lib/dialyzer.ex
@@ -5,12 +5,12 @@ defmodule Mix.Tasks.Dialyzer do
   @shortdoc "Runs dialyzer with default or project-defined flags."
 
   @moduledoc """
-  Runs dialyzer with default flags: 
+  Runs dialyzer with default flags:
     -Wunmatched_returns -Werror_handling -Wrace_conditions -Wunderspecs
 
   You can define a dialyzer_flags key in your Mix project config to override defaults.
   You can also include a dialyzer_paths key to override default path (only Mix.Project.app_path()/ebin)
-  
+
   e.g.
     def project do
       [ app: :my_app,
@@ -39,12 +39,11 @@ defmodule Mix.Tasks.Dialyzer do
   import Enum, only: [join: 2]
 
   defp dialyzer_flags do
-    (Mix.project[:dialyzer][:flags]
+    (Mix.Project.config[:dialyzer][:flags]
       || ["-Wunmatched_returns","-Werror_handling","-Wrace_conditions","-Wunderspecs"])
       |> join(" ")
   end
 
-  defp dialyzer_paths, do: (Mix.project[:dialyzer][:paths] || [ Path.join(Mix.Project.app_path, "ebin") ]) |> join(" ")
+  defp dialyzer_paths, do: (Mix.Project.config[:dialyzer][:paths] || [ Path.join(Mix.Project.app_path, "ebin") ]) |> join(" ")
 
 end
-

--- a/lib/dialyzer.plt.ex
+++ b/lib/dialyzer.plt.ex
@@ -60,7 +60,7 @@ defmodule Mix.Tasks.Dialyzer.Plt do
   end
 
   def plt_file do
-    Mix.project[:dialyzer][:plt_file]
+    Mix.Project.config[:dialyzer][:plt_file]
       || "#{user_home!}/.dialyxir_core_#{:erlang.system_info(:otp_release)}_#{version}.plt"
   end
 
@@ -88,13 +88,13 @@ defmodule Mix.Tasks.Dialyzer.Plt do
     end
   end
 
-  defp plt_apps, do: Mix.project[:dialyzer][:plt_apps]
-  defp plt_add_apps, do: Mix.project[:dialyzer][:plt_add_apps] || []
+  defp plt_apps, do: Mix.Project.config[:dialyzer][:plt_apps]
+  defp plt_add_apps, do: Mix.Project.config[:dialyzer][:plt_add_apps] || []
   defp default_apps, do: [:erts, :kernel, :stdlib, :crypto, :public_key]
 
-  defp include_deps, do: (if Mix.project[:dialyzer][:plt_add_deps], do: deps_apps, else: [])
+  defp include_deps, do: (if Mix.Project.config[:dialyzer][:plt_add_deps], do: deps_apps, else: [])
   defp deps_apps do
-    Mix.project[:deps] |> Enum.map(&elem(&1,0))
+    Mix.Project.config[:deps] |> Enum.map(&elem(&1,0))
   end
 
   defp need_build? do


### PR DESCRIPTION
`Mix.project` was deprecated in the `0.13.*` releases, and removed in `0.14.0` (the current master). So this PR just basically removes the call to the former and replaces them with the latter.
