### PR TITLE
Fix compile error due to nonexisting `atom_to_binary`

### DIFF
--- a/lib/dialyzer.plt.ex
+++ b/lib/dialyzer.plt.ex
@@ -74,7 +74,7 @@ defmodule Mix.Tasks.Dialyzer.Plt do
   defp include_apps, do: Enum.map_join(cons_apps," ", &to_binary_if_atom(&1))
 
   defp to_binary_if_atom(b) when is_binary(b), do: b
-  defp to_binary_if_atom(a) when is_atom(a), do: atom_to_binary(a)
+  defp to_binary_if_atom(a) when is_atom(a), do: Atom.to_string(a)
 
   defp cons_apps, do: ((plt_apps || (default_apps ++ plt_add_apps)) ++ include_deps)
 
@@ -83,7 +83,7 @@ defmodule Mix.Tasks.Dialyzer.Plt do
       [] -> ""
       apps ->
         Enum.map_join(apps, fn(a) ->
-          " -pa deps/" <> atom_to_binary(a)
+          " -pa deps/" <> Atom.to_string(a)
           <> "/ebin" end)
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,6 +4,7 @@ defmodule Dialyxir.Mixfile do
   def project do
     [ app: :dialyxir,
       version: "0.2.3",
+      elixir: ">= 0.13.3",
       deps: deps
     ]
   end


### PR DESCRIPTION
Unfortunately compiling dialyxir with elixir-0.14.2 fails as follows:

``` shell
$ mix compile
== Compilation error on file lib/dialyzer.plt.ex ==
** (CompileError) lib/dialyzer.plt.ex:77: function atom_to_binary/1 undefined
    (stdlib) lists.erl:1336: :lists.foreach/2
    (stdlib) erl_eval.erl:657: :erl_eval.do_apply/6
    (elixir) src/elixir.erl:163: :elixir.erl_eval/2
    (elixir) src/elixir.erl:156: :elixir.eval_forms/4
    (elixir) src/elixir_lexical.erl:17: :elixir_lexical.run/2
    (elixir) src/elixir.erl:163: :elixir.erl_eval/2
```

This pull request simply replaces `atom_to_binary` with `Atom.to_string` as explained in https://github.com/elixir-lang/elixir/releases.

Just for reference:
- `Atom.to_string` is defined in [this commit](https://github.com/elixir-lang/elixir/commit/deb0191a2144dd890195081110e942437a963341).
- `atom_to_binary` is removed in [this commit](https://github.com/elixir-lang/elixir/commit/feb9cb645ed6f4199979e5fb9ff832b83c701a25).

Thanks!
