### PR TITLE
Do not pass --quiet to dialyzer

### DIFF
--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -32,7 +32,7 @@ defmodule Mix.Tasks.Dialyzer do
   def run(args) do
     puts "Starting Dialyzer"
     argStr = Enum.join args, " "
-    cmds = "dialyzer #{argStr} --quiet --no_check_plt --plt #{Plt.plt_file} #{dialyzer_flags} #{dialyzer_paths}"
+    cmds = "dialyzer #{argStr} --no_check_plt --plt #{Plt.plt_file} #{dialyzer_flags} #{dialyzer_paths}"
     puts cmds
     puts System.cmd(cmds)
   end


### PR DESCRIPTION
Passing `--quiet` means that dialyzer will not warn on missing types or functions, leading to bad analysis.
