### PR TITLE
Fix missing -pe option

### DIFF
--- a/lib/mix/tasks/dialyzer.plt.ex
+++ b/lib/mix/tasks/dialyzer.plt.ex
@@ -111,7 +111,7 @@ defmodule Mix.Tasks.Dialyzer.Plt do
     puts "Some apps are missing and will be added:"
     puts Enum.join(apps, " ")
     puts "Adding Erlang/OTP Apps to existing PLT ... this will take a little time"
-    args = List.flatten ["--add_to_plt", "--plt", "#{plt_file}", "--apps", apps]
+    args = List.flatten ["--add_to_plt", "--plt", "#{plt_file}", include_pa, "--apps", apps]
     puts "dialyzer " <> Enum.join(args, " ")
     {ret, _} = cmd("dialyzer", args, [])
     puts ret


### PR DESCRIPTION
I ran into the same problem reported in #31. Under the project which have `plt_add_deps: true` option, `mix dialyxir.plt` doesn't add `-pe` option if PLT file already exists.

```
% mix dialyzer.plt
Some apps are missing and will be added:
poison httpoison joken phoenix phoenix_ecto mariaex phoenix_html phoenix_live_reload cowboy
Adding Erlang/OTP Apps to existing PLT ... this will take a little time
dialyzer --add_to_plt --plt /Users/takanori_is/.dialyxir_core_18_1.2.0-dev.plt --apps poison httpoison joken phoenix phoenix_ecto mariaex phoenix_html phoenix_live_reload cowboy

dialyzer: No such file, directory or application: "poison"
```