### PR TITLE
support --halt-exit-status option

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Dialyxir.Mixfile do
   def project do
     [
       app: :dialyxir,
-      version: "0.3.0",
+      version: "0.3.1",
       elixir: "~> 1.0",
       description: description,
       package: package,


### PR DESCRIPTION
This implements #33. I could not find a way for dialyzer to exit with status 1, so I could check only 0 and 2.