### PR TITLE
improve support for umbrella projects

### DIFF
--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -57,7 +57,25 @@ defmodule Mix.Tasks.Dialyzer do
     || ["-Wunmatched_returns", "-Werror_handling", "-Wrace_conditions", "-Wunderspecs"]
   end
 
+  defp umbrella_childeren_apps do
+    (Mix.Project.config[:apps_path] <> "/*/mix.exs")
+    |> Path.wildcard
+    |> Enum.map(&Path.basename(Path.dirname(&1)))
+  end
+
+  defp app_path(app_name) do
+    Path.join([Path.relative_to_cwd(Mix.Project.build_path), "lib", app_name, "ebin"])
+  end
+
+  defp default_paths(true = _umbrella?) do
+    umbrella_childeren_apps
+    |> Enum.map(&app_path/1)
+  end
+  defp default_paths(false = _umbrella?) do
+    [ Path.join(Mix.Project.app_path, "ebin") ]
+  end
+
   defp dialyzer_paths do
-    Mix.Project.config[:dialyzer][:paths] || [ Path.join(Mix.Project.app_path, "ebin") ]
+    Mix.Project.config[:dialyzer][:paths] || default_paths(Mix.Project.umbrella?)
   end
 end


### PR DESCRIPTION
set default for `paths` for umbrella projects to list of in-umbrella
applications.