### PR TITLE
Fix umbrella app build paths to include Mix.env in them. Fix typo.

### DIFF
--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -57,19 +57,19 @@ defmodule Mix.Tasks.Dialyzer do
     || ["-Wunmatched_returns", "-Werror_handling", "-Wrace_conditions", "-Wunderspecs"]
   end
 
-  defp umbrella_childeren_apps do
+  defp umbrella_children_apps do
     (Mix.Project.config[:apps_path] <> "/*/mix.exs")
     |> Path.wildcard
     |> Enum.map(&Path.basename(Path.dirname(&1)))
   end
 
-  defp app_path(app_name) do
+  defp build_path(app_name) do
     Path.join([Path.relative_to_cwd(Mix.Project.build_path), "lib", app_name, "ebin"])
   end
 
   defp default_paths(true = _umbrella?) do
-    umbrella_childeren_apps
-    |> Enum.map(&app_path/1)
+    umbrella_children_apps
+    |> Enum.map(&build_path/1)
   end
   defp default_paths(false = _umbrella?) do
     [ Path.join(Mix.Project.app_path, "ebin") ]


### PR DESCRIPTION
My umbrella project was failing to dialyze with dialyxir, because the 'dialyzer_paths' for the projects included in the umbrella were all missing the Mix.env portion of the path. The paths used were of the form '_build/lib/app_name/ebin', when the beam files were actually in '_build/dev/lib/app_name/ebin'. Using Mix.Project.build_path() instead of Mix.Project.app_path() fixed this for me.

Are there cases where the old behavior is correct and a check would be needed whether to use the old or the new behavior?

Also fixed a typo: childeren -> children.