### PR TITLE
Compilation fixes for develop

### DIFF
--- a/lib/dialyxir/project.ex
+++ b/lib/dialyxir/project.ex
@@ -22,7 +22,7 @@ defmodule Dialyxir.Project do
   end
 
   def cons_apps do
-    Mix.Tasks.Deps.Check.run([]) #compile & load all deps paths
+    Mix.Tasks.Deps.Loadpaths.run([]) #compile & load all deps paths
     Mix.Project.compile([]) # compile & load current project paths
     (plt_apps() || (plt_add_apps() ++ include_deps()))
       |> Enum.sort |> Enum.uniq

--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -82,6 +82,7 @@ defmodule Mix.Tasks.Dialyzer do
   """
 
   use Mix.Task
+  alias Dialyxir.Project
   import Dialyxir.Helpers
   import System, only: [user_home!: 0]
 

--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -82,6 +82,7 @@ defmodule Mix.Tasks.Dialyzer do
   """
 
   use Mix.Task
+  alias Dialyxir.Plt
   alias Dialyxir.Project
   import Dialyxir.Helpers
   import System, only: [user_home!: 0]


### PR DESCRIPTION
Fix these compilation warnings:

```
warning: function Project.check_config/0 is undefined (module Project is not available)
  lib/mix/tasks/dialyzer.ex:90

warning: function Project.dialyzer_paths/0 is undefined (module Project is not available)
  lib/mix/tasks/dialyzer.ex:96

warning: function Project.plt_file/0 is undefined (module Project is not available)
Found at 3 locations:
  lib/mix/tasks/dialyzer.ex:96
  lib/mix/tasks/dialyzer.ex:106
  lib/mix/tasks/dialyzer.ex:153

warning: function Plt.check/1 is undefined (module Plt is not available)
  lib/mix/tasks/dialyzer.ex:106

warning: function Plt.plts_list/2 is undefined (module Plt is not available)
  lib/mix/tasks/dialyzer.ex:106

warning: function Plt.elixir_plt/0 is undefined (module Plt is not available)
  lib/mix/tasks/dialyzer.ex:128

warning: function Plt.erlang_plt/0 is undefined (module Plt is not available)
  lib/mix/tasks/dialyzer.ex:128

warning: function Project.cons_apps/0 is undefined (module Project is not available)
  lib/mix/tasks/dialyzer.ex:158

warning: function Mix.Tasks.Deps.Check.run/1 is undefined (module Mix.Tasks.Deps.Check is not available)
  lib/dialyxir/project.ex:25
```