### PR TITLE
Fix instructions to install globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To install globally as an archive:
 ```console
 git clone https://github.com/jeremyjh/dialyxir
 cd dialyxir
-mix do compile, archive.build, archive.install
+mix do deps.get, compile, archive.build, archive.install
 ```
 
 ## Usage


### PR DESCRIPTION
Add `deps.get` otherwise this error is given.

```sh
Unchecked dependencies for environment dev:
* ex_doc (Hex package)
  the dependency is not available, run "mix deps.get"
** (Mix) Can't continue due to errors on dependencies
```