### PR TITLE
Enable dialyzer.ignore-warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,4 +133,48 @@ end
 
 ### Ignore Warnings
 
-**TODO**
+If you want to ignore well-known warnings, you can specify file path to `:ignore_warnings`.
+
+```elixir
+def project do
+ [ app: :my_app,
+   version: "0.0.1",
+   deps: deps,
+   dialyzer: [ignore_warnings: "dialyzer.ignore-warnings"]
+ ]
+end
+```
+
+If an each line of dialyzer output matches an any each line in `"dialyzer.ignore-warnings"`, the line is filtered.
+
+For example, dialyzer outputs here:
+
+```
+  Proceeding with analysis...
+config.ex:64: The call ets:insert('Elixir.MyApp.Config',{'Elixir.MyApp.Config',_}) might have an unintended effect due to a possible race condition caused by its combination withthe ets:lookup('Elixir.MyApp.Config','Elixir.MyApp.Config') call in config.ex on line 26
+config.ex:79: Guard test is_binary(_@5::#{'__exception__':='true', '__struct__':=_, _=>_}) can never succeed
+config.ex:79: Guard test is_atom(_@6::#{'__exception__':='true', '__struct__':=_, _=>_}) can never succeed
+ done in 0m1.32s
+done (warnings were emitted)
+```
+
+If you want to ignore well-known warnings are two lines starts with `Guard test`, you write down to `dialyzer.ignore-warnings`.
+
+```
+Guard test is_binary(_@5::#{'__exception__':='true', '__struct__':=_, _=>_}) can never succeed
+Guard test is_atom(_@6::#{'__exception__':='true', '__struct__':=_, _=>_}) can never succeed
+```
+
+And then run `mix dialyzer` outputs here:
+
+```
+  Proceeding with analysis...
+config.ex:64: The call ets:insert('Elixir.MyApp.Config',{'Elixir.MyApp.Config',_}) might have an unintended effect due to a possible race condition caused by its combination withthe ets:lookup('Elixir.MyApp.Config','Elixir.MyApp.Config') call in config.ex on line 26
+ done in 0m1.32s
+done (warnings were emitted)
+```
+
+Specified warnings are filtered.
+
+`:ignore_warnings` can combined with `--halt-exit-status`.
+If all warnings are filtered by the specified ignoring file, exit status is 0 otherwise 1.

--- a/README.md
+++ b/README.md
@@ -130,3 +130,7 @@ def project do
  ]
 end
 ```
+
+### Ignore Warnings
+
+**TODO**

--- a/lib/dialyxir/project.ex
+++ b/lib/dialyxir/project.ex
@@ -41,6 +41,10 @@ defmodule Dialyxir.Project do
     dialyzer_config[:paths] || default_paths()
   end
 
+  def dialyzer_ignore_warnings do
+    dialyzer_config[:ignore_warnings]
+  end
+
   def elixir_plt() do
     global_plt("erlang-#{otp_vsn()}_elixir-#{System.version()}")
   end

--- a/lib/dialyxir/project.ex
+++ b/lib/dialyxir/project.ex
@@ -45,6 +45,18 @@ defmodule Dialyxir.Project do
     dialyzer_config[:ignore_warnings]
   end
 
+  def filter_warnings(output, pattern) do
+    lines = output
+            |> String.trim_trailing("\n")
+            |> String.split("\n")
+    patterns = pattern
+               |> String.trim_trailing("\n")
+               |> String.split("\n")
+    cp = :binary.compile_pattern(patterns)
+
+    Enum.filter(lines, &(not String.contains?(&1, cp)))
+  end
+
   def elixir_plt() do
     global_plt("erlang-#{otp_vsn()}_elixir-#{System.version()}")
   end

--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -72,6 +72,8 @@ defmodule Mix.Tasks.Dialyzer do
   * `dialyzer: :plt_file` - Deprecated - specify the plt file name to create and use - default is to create one in the project's current build environmnet (e.g. _build/dev/) specific to the Erlang/Elixir version used. Note that use of this key in version 0.4 or later will produce a deprecation warning - you can silence the warning by providing a pair with key :no_warn e.g. `plt_file: {:no_warn,"filename"}`.
 
   * `dialyzer: :plt_core_path` - specify an alternative to MIX_HOME to use to store the Erlang and Elixir core files.
+
+  * `dialyzer: :ignore_warnings` - specify file path to filter well-known warnings.
   """
 
   use Mix.Task

--- a/test/dialyxir/project_test.exs
+++ b/test/dialyxir/project_test.exs
@@ -111,4 +111,23 @@ defmodule Dialyxir.ProjectTest do
     end
   end
 
+  test "Filtered dialyzer warnings" do
+    in_project :default_apps, fn ->
+      output = ~S"""
+        Proceeding with analysis...
+      project.ex:9: Guard test is_atom(_@5::#{'__exception__':='true', '__struct__':=_, _=>_}) can never succeed
+      project.ex:9: Guard test is_binary(_@4::#{'__exception__':='true', '__struct__':=_, _=>_}) can never succeed
+       done in 0m6.69s
+      done (warnings were emitted)
+      """
+      pattern = ~S"""
+      Guard test is_atom(_@5::#{'__exception__':='true', '__struct__':=_, _=>_}) can never succeed
+      Guard test is_binary(_@4::#{'__exception__':='true', '__struct__':=_, _=>_}) can never succeed
+      """
+      lines = Project.filter_warnings(output, pattern)
+      assert lines == ["  Proceeding with analysis...",
+                       " done in 0m6.69s",
+                       "done (warnings were emitted)"]
+    end
+  end
 end

--- a/test/dialyxir/project_test.exs
+++ b/test/dialyxir/project_test.exs
@@ -105,4 +105,10 @@ defmodule Dialyxir.ProjectTest do
     end
   end
 
+  test "By default a dialyzer ignore file is nil" do
+    in_project :default_apps, fn ->
+      assert Project.dialyzer_ignore_warnings == nil
+    end
+  end
+
 end


### PR DESCRIPTION
I want to ignore well-known dialyzer warnings.

It seems that Erlang users make a file `dialyzer.ignore-warnings` and run command:

```
dialyzer ... | fgrep -v -f ./dialyzer.ignore-warnings
```

Many Erlang projects using [dialyzer.ignore-warnings](https://github.com/search?utf8=%E2%9C%93&q=filename%3Adialyzer.ignore-warnings&type=Code&ref=searchresults)