### PR TITLE
Display full paths of offending files

### DIFF
--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -95,7 +95,7 @@ defmodule Mix.Tasks.Dialyzer do
                  end
       if compile == [], do: Mix.Project.compile([])
       unless no_check != [], do: check_plt()
-      args = List.flatten [dargs, "--no_check_plt", "--plt", "#{Project.plt_file()}", dialyzer_flags(), Project.dialyzer_paths()]
+      args = List.flatten [dargs, "--no_check_plt", "--plt", "--fullpath", "#{Project.plt_file()}", dialyzer_flags(), Project.dialyzer_paths()]
       dialyze(args, halt)
     else
       IO.puts "No mix project found - checking core PLTs..."


### PR DESCRIPTION
This changes the output to always display the path to the file:
`lib/my_lib/foo/my_module.ex:32: Function publish/6 has no local return`
instead of
`my_module.ex:32: Function publish/6 has no local return`

I looked and didn't find any previous discussion of this. To me it doesn't seem like there is any reason to not display the full path.