### PR TITLE
Fix parentheses warnings for Elixir 1.4

### DIFF
--- a/lib/dialyxir/project.ex
+++ b/lib/dialyxir/project.ex
@@ -13,7 +13,7 @@ defmodule Dialyxir.Project do
   end
 
   def plt_file() do
-    plt_path(dialyzer_config[:plt_file])
+    plt_path(dialyzer_config()[:plt_file])
     || deps_plt()
   end
   defp plt_path(file) when is_binary(file), do: Path.expand(file)
@@ -21,7 +21,7 @@ defmodule Dialyxir.Project do
   defp plt_path(_),  do: false
 
   def check_config do
-    if is_binary(dialyzer_config[:plt_file]) do
+    if is_binary(dialyzer_config()[:plt_file]) do
       IO.puts """
       Notice: :plt_file is deprecated as Dialyxir now uses project-private PLT files by default.
       If you want to use this setting without seeing this warning, provide it in a pair
@@ -38,11 +38,11 @@ defmodule Dialyxir.Project do
   end
 
   def dialyzer_paths do
-    dialyzer_config[:paths] || default_paths()
+    dialyzer_config()[:paths] || default_paths()
   end
 
   def dialyzer_ignore_warnings do
-    dialyzer_config[:ignore_warnings]
+    dialyzer_config()[:ignore_warnings]
   end
 
   def filter_warnings(output, pattern) do
@@ -97,7 +97,7 @@ defmodule Dialyxir.Project do
     Path.join(core_path(), "dialyxir_" <> name <> ".plt")
   end
 
-  defp core_path(), do: dialyzer_config[:plt_core_path] || Mix.Utils.mix_home()
+  defp core_path(), do: dialyzer_config()[:plt_core_path] || Mix.Utils.mix_home()
 
   defp local_plt(name) do
     Path.join(Mix.Project.build_path(), "dialyxir_" <> name <> ".plt")
@@ -109,8 +109,8 @@ defmodule Dialyxir.Project do
     end)
   end
 
-  defp plt_apps, do: dialyzer_config[:plt_apps] |> load_apps()
-  defp plt_add_apps, do: dialyzer_config[:plt_add_apps] || [] |> load_apps()
+  defp plt_apps, do: dialyzer_config()[:plt_apps] |> load_apps()
+  defp plt_add_apps, do: dialyzer_config()[:plt_add_apps] || [] |> load_apps()
   defp load_apps(apps) do
     if apps do
       Enum.map(apps, &Application.load/1)
@@ -119,7 +119,7 @@ defmodule Dialyxir.Project do
   end
 
   defp include_deps do
-    method = dialyzer_config[:plt_add_deps]
+    method = dialyzer_config()[:plt_add_deps]
     reduce_umbrella_children([],fn(deps) ->
       deps ++ case method do
         false         -> []

--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -40,7 +40,7 @@ defmodule Mix.Tasks.Dialyzer do
 
   ### PLT Configuration
 
-  The task will build a PLT with default core Erlang applications: `:erts :kernel :stdlib :crypto` and re-use this core file in multiple projects - another core file is created for Elixir. 
+  The task will build a PLT with default core Erlang applications: `:erts :kernel :stdlib :crypto` and re-use this core file in multiple projects - another core file is created for Elixir.
 
   OTP application dependencies are (transitively) added to your project's PLT by default. The applications added are the same as you would see displayed with the command `mix app.tree`. There is also a `:plt_add_deps` option you can set to control the dependencies added. The following options are supported:
 
@@ -89,7 +89,7 @@ defmodule Mix.Tasks.Dialyzer do
       {dargs, compile} = Enum.partition(args, &(&1 != "--no-compile"))
       {dargs, halt} = Enum.partition(dargs, &(&1 != "--halt-exit-status"))
       {dargs, no_check} = Enum.partition(dargs, &(&1 != "--no-check"))
-      no_check = if in_child? do
+      no_check = if in_child?() do
                     IO.puts "In an Umbrella child, not checking PLT..."
                     ["--no-check"]
                  else
@@ -108,12 +108,12 @@ defmodule Mix.Tasks.Dialyzer do
 
   defp check_plt() do
     IO.puts "Checking PLT..."
-    {apps, hash} = dependency_hash
+    {apps, hash} = dependency_hash()
     if check_hash?(hash) do
       IO.puts "PLT is up to date!"
     else
       Project.plts_list(apps) |> Plt.check()
-      File.write(plt_hash_file, hash)
+      File.write(plt_hash_file(), hash)
     end
   end
 
@@ -207,7 +207,7 @@ defmodule Mix.Tasks.Dialyzer do
 
   @spec check_hash?(binary()) :: boolean()
   defp check_hash?(hash) do
-	  case File.read(plt_hash_file) do
+	  case File.read(plt_hash_file()) do
       {:ok, stored_hash} -> hash == stored_hash
       _ -> false
     end


### PR DESCRIPTION
Elixir 1.4 gives this warning:
```
warning: variable "dialyzer_config" does not exist and is being expanded to "dialyzer_config()",
please use parentheses to remove the ambiguity or change the variable name
  lib/dialyxir/project.ex:16
```