### PR TITLE
Enable warnings-as-errors on CI and fix parentheses warnings in mix task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ otp_release:
   - 19.2
 script:
   - mix test
-  - MIX_ENV=prod mix do compile, archive.build, archive.install --force
+  - MIX_ENV=prod mix do compile --warnings-as-errors, archive.build, archive.install --force
   - MIX_ENV=prod mix dialyzer --halt-exit-status
 branches:
   except:

--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -95,7 +95,7 @@ defmodule Mix.Tasks.Dialyzer do
       {opts, _, dargs} = OptionParser.parse(args, strict: @command_options)
       dargs = Enum.map(dargs, &elem(&1,0))
 
-      no_check = case {in_child?, no_plt?} do
+      no_check = case {in_child?(), no_plt?()} do
                    {true, true} ->
                      IO.puts "In an Umbrella child and no PLT found - building that first."
                      build_parent_plt()


### PR DESCRIPTION
This changes the build to pass `--warnings-as-errors` to `mix compile` so warnings don't sneak through. :)