### PR TITLE
Make PLT bullet points render on github

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ Usage is straightforward but you should be aware of the available configuration 
 The Persistent Lookup Table (PLT) is basically a cached output of the analysis. This is important because you'd probably stab yourself in the eye with
 a fork if you had to wait for Dialyzer to analyze all the standard library and OTP modules you are using everytime you ran it.
 Running the mix task `dialyzer` by default builds several PLT files:
-    * A core Erlang file in $MIX_HOME/dialyxir_erlang-[OTP Version].plt
-    * A core Elixir file in $MIX_HOME/dialyxir_erlang-[OTP Version]_elixir-[Elixir Version].plt
-    * A project environment specific file in _build/env/dialyze_erlang-[OTP Version]_elixir-[Elixir Version]_deps-dev.plt
+  * A core Erlang file in $MIX_HOME/dialyxir_erlang-[OTP Version].plt
+  * A core Elixir file in $MIX_HOME/dialyxir_erlang-[OTP Version]_elixir-[Elixir Version].plt
+  * A project environment specific file in _build/env/dialyze_erlang-[OTP Version]_elixir-[Elixir Version]_deps-dev.plt
 
 The core files are simply copied to your project folder when you run `dialyxir` for the first time with a given version of Erlang and Elixir. By default, all
 the modules in the project PLT are checked against your dependencies to be sure they are up to date. If you do not want to use MIX_HOME to store your core Erlang and Elixir files, you can provide a :plt_core_path key with a file path. You can specify a different location for the project PLT file with the :plt_file keyword - this is deprecated because people were using it with the old `dialyxir` to have project-specific PLTs, which are now the default. To silence the deprecation warning, specify this value as `plt_file: {:no_warn, "/myproject/mypltfile"}`.


### PR DESCRIPTION
Previously the bullet points in the PLT section looked like this on Github:

<img width="895" alt="screen shot 2017-03-31 at 6 15 15 pm" src="https://cloud.githubusercontent.com/assets/1301625/24571274/0cd9b838-163e-11e7-81d9-bd0509005121.png">

Now they are formatted nicely.