### PR TITLE
Allow inclusion of blank lines in ignore file

### DIFF
--- a/lib/dialyxir/project.ex
+++ b/lib/dialyxir/project.ex
@@ -70,6 +70,7 @@ defmodule Dialyxir.Project do
         patterns = pattern
         |> String.trim_trailing("\n")
         |> String.split("\n")
+        |> Enum.reject(&(&1 == ""))
         try do
           cp = :binary.compile_pattern(patterns)
           Enum.filter(lines, &(not String.contains?(&1, cp)))

--- a/test/dialyxir/project_test.exs
+++ b/test/dialyxir/project_test.exs
@@ -121,6 +121,7 @@ defmodule Dialyxir.ProjectTest do
 
       pattern = ~S"""
       Guard test is_atom(_@5::#{'__exception__':='true', '__struct__':=_, _=>_}) can never succeed
+
       Guard test is_binary(_@4::#{'__exception__':='true', '__struct__':=_, _=>_}) can never succeed
       """
       lines = Project.filter_warnings(output_list, pattern)


### PR DESCRIPTION
I tried to use some blank lines to split up groups of lines in my file
of patterns to ignore, and discovered that if I added a blank line then
no filtering was done.

This is because `:binary.compile_pattern/1` treats an empty string in
the patterns as an argument error.

As a blank line isn't a meaningful thing to match using
String.contains?/2 (because all strings contain the empty string), it
seems to me that we can filter out blank lines in the ignore file so
that they can be used to separate chunks of patterns.