### PR TITLE
Release for Elixir 1.5.0.

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.5.0
+erlang 20.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: elixir
 elixir:
-  - 1.3.4
-  - 1.4.0
+  - 1.4.5
   - 1.5.0
 otp_release:
   - 19.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: elixir
 elixir:
   - 1.3.4
   - 1.4.0
+  - 1.5.0
 otp_release:
   - 19.2
+  - 20.0
 script:
   - mix test
   - MIX_ENV=prod mix do compile --warnings-as-errors, archive.build, archive.install --force

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Dialyxir.Mixfile do
   def project do
     [
       app: :dialyxir,
-      version: "0.5.0",
+      version: "0.5.1",
       elixir: "> 1.3.2",
       description: description(),
       package: package(),


### PR DESCRIPTION
 * Publishing as 0.5.1 to address Elixir 1.5.0 compilation warnings.
 * Update travis to build with 1.5 and OTP 20