### PR TITLE
Fix error on failed plt_build

### DIFF
--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -168,7 +168,7 @@ defmodule Mix.Tasks.Dialyzer do
 
   defp build_parent_plt() do
     parent = Mix.Project.config[:lockfile] |> Path.expand |> Path.dirname
-    opts = [ into: IO.stream(:stdio, :line),
+    opts = [ into: "",
              stderr_to_stdout: true,
              cd: parent ]
     # It would seem more natural to use Mix.in_project here to start in our parent project.


### PR DESCRIPTION
When I was running mix dialyzer on a misconfigured project, I got the following error:

```** (Protocol.UndefinedError) protocol String.Chars not implemented for %IO.Stream{device: :standard_io, line_or_bytes: :line, raw: false}
    (elixir) lib/string/chars.ex:3: String.Chars.impl_for!/1
    (elixir) lib/string/chars.ex:22: String.Chars.to_string/1
    lib/mix/tasks/dialyzer.ex:179: Mix.Tasks.Dialyzer.build_parent_plt/0
    lib/mix/tasks/dialyzer.ex:113: Mix.Tasks.Dialyzer.no_check?/1
    lib/mix/tasks/dialyzer.ex:101: Mix.Tasks.Dialyzer.run/1
    (mix) lib/mix/task.ex:301: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:75: Mix.CLI.run_task/2
    (elixir) lib/code.ex:376: Code.require_file/2
```

I'm not sure what's changed with `IO.Stream` in recent versions of elixir, but this change fixes the problem (and the log of the failed dialyzer run still outputs)