### PR TITLE
Formatter support strings with length != 1

### DIFF
--- a/src/struct_parser.yrl
+++ b/src/struct_parser.yrl
@@ -84,6 +84,7 @@ function -> 'fun(' list '->' value ')' : {function, {args, '$2'}, {return, '$4'}
 
 contract -> list '->' value : {contract, {args, '$1'}, {return, '$3'}}.
 
+ascii_list -> '#' '{' '}' '#' : {ascii, []}.
 ascii_list -> '#' '{' ascii_items '}' '#' : {ascii, '$3'}.
 
 ascii_items -> ascii : ['$1'].

--- a/src/struct_parser.yrl
+++ b/src/struct_parser.yrl
@@ -7,6 +7,8 @@ list list_items
 struct struct_items
 tuple tuple_items
 pattern pattern_items
+ascii_list ascii_items
+ascii
 named_value
 range
 contract
@@ -22,7 +24,6 @@ document -> values : '$1'.
 values -> value : ['$1'].
 values -> value values : ['$1'] ++ '$2'.
 
-value -> '#' '{' '#' '<' int '>' '(' int ',' int ',' '\'' atom '\'' ',' '[' '\'' atom '\'' ',' '\'' atom '\'' ']' ')' '}' '#' : {ascii, unwrap('$5')}.
 value -> atom : {atom, unwrap('$1')}.
 value -> '<<' value ':' value '>>' : {binary, '$2', '$4'}.
 value -> struct : '$1'.
@@ -46,6 +47,7 @@ value -> pattern : '$1'.
 value -> function : '$1'.
 value -> contract : '$1'.
 value -> range : '$1'.
+value -> ascii_list : '$1'.
 
 value -> '\'' value '|' value '\'' : {pipe_list, '$2', '$4'}.
 value -> value '|' value : {pipe_list, '$1', '$3'}.
@@ -81,6 +83,13 @@ function -> 'fun(' empty_list_paren '->' value ')' : {function, {args, '$2'}, {r
 function -> 'fun(' list '->' value ')' : {function, {args, '$2'}, {return, '$4'}}.
 
 contract -> list '->' value : {contract, {args, '$1'}, {return, '$3'}}.
+
+ascii_list -> '#' '{' ascii_items '}' '#' : {ascii, '$3'}.
+
+ascii_items -> ascii : ['$1'].
+ascii_items -> ascii ',' ascii_items : ['$1'] ++ '$3'.
+
+ascii -> '#' '<' int '>' '(' int ',' int ',' '\'' atom '\'' ',' '[' '\'' atom '\'' ',' '\'' atom '\'' ']' ')' : unwrap('$3').
 
 Erlang code.
 


### PR DESCRIPTION
Minor improvement for issue with strings reported 2 days ago https://github.com/jeremyjh/dialyxir/pull/118#issuecomment-384486361

Now it should support empty strings as well as strings longer than 1 char.

Tested with 
```elixir
defmodule StringIssue2 do
  def single_arg do
    do_single_arg("")
  end

  def multiple_args do
    do_multiple_args("", 12345)
  end

  defp do_single_arg(var1) when is_atom(var1), do: :ok
  defp do_multiple_args(var1, _var2) when is_atom(var1), do: :ok
end

defmodule StringIssue3 do
  def single_arg do
    do_single_arg("String")
  end

  def multiple_args do
    do_multiple_args("String", 12345)
  end

  defp do_single_arg(var1) when is_atom(var1), do: :ok
  defp do_multiple_args(var1, _var2) when is_atom(var1), do: :ok
end
```