### PR TITLE
formatter support for non-ascii strings and non-string binaries

### DIFF
--- a/lib/dialyxir/pretty_print.ex
+++ b/lib/dialyxir/pretty_print.ex
@@ -72,8 +72,10 @@ defmodule Dialyxir.PrettyPrint do
     "_"
   end
 
-  defp do_pretty_print({:ascii, n}) do
-    "\"#{[n]}\""
+  defp do_pretty_print({:byte_list, byte_list}) do
+    binary = for byte <- byte_list, into: <<>>, do: <<byte :: 8>>
+
+    inspect(binary)
   end
 
   # TODO: Not sure what the middle value is here.

--- a/lib/dialyxir/pretty_print.ex
+++ b/lib/dialyxir/pretty_print.ex
@@ -73,9 +73,11 @@ defmodule Dialyxir.PrettyPrint do
   end
 
   defp do_pretty_print({:byte_list, byte_list}) do
-    binary = for byte <- byte_list, into: <<>>, do: <<byte :: 8>>
-
-    inspect(binary)
+    byte_list
+    |> Enum.into(<<>>, fn byte ->
+      <<byte :: 8>>
+    end)
+    |> inspect()
   end
 
   # TODO: Not sure what the middle value is here.

--- a/src/struct_parser.yrl
+++ b/src/struct_parser.yrl
@@ -7,8 +7,8 @@ list list_items
 struct struct_items
 tuple tuple_items
 pattern pattern_items
-ascii_list ascii_items
-ascii
+byte_list byte_items
+byte
 named_value
 range
 contract
@@ -47,7 +47,7 @@ value -> pattern : '$1'.
 value -> function : '$1'.
 value -> contract : '$1'.
 value -> range : '$1'.
-value -> ascii_list : '$1'.
+value -> byte_list : '$1'.
 
 value -> '\'' value '|' value '\'' : {pipe_list, '$2', '$4'}.
 value -> value '|' value : {pipe_list, '$1', '$3'}.
@@ -84,13 +84,13 @@ function -> 'fun(' list '->' value ')' : {function, {args, '$2'}, {return, '$4'}
 
 contract -> list '->' value : {contract, {args, '$1'}, {return, '$3'}}.
 
-ascii_list -> '#' '{' '}' '#' : {ascii, []}.
-ascii_list -> '#' '{' ascii_items '}' '#' : {ascii, '$3'}.
+byte_list -> '#' '{' '}' '#' : {byte_list, []}.
+byte_list -> '#' '{' byte_items '}' '#' : {byte_list, '$3'}.
 
-ascii_items -> ascii : ['$1'].
-ascii_items -> ascii ',' ascii_items : ['$1'] ++ '$3'.
+byte_items -> byte : ['$1'].
+byte_items -> byte ',' byte_items : ['$1'] ++ '$3'.
 
-ascii -> '#' '<' int '>' '(' int ',' int ',' '\'' atom '\'' ',' '[' '\'' atom '\'' ',' '\'' atom '\'' ']' ')' : unwrap('$3').
+byte -> '#' '<' int '>' '(' int ',' int ',' '\'' atom '\'' ',' '[' '\'' atom '\'' ',' '\'' atom '\'' ']' ')' : unwrap('$3').
 
 Erlang code.
 


### PR DESCRIPTION
Tested on 
```elixir
defmodule StringIssue do
  def single_arg do
    do_single_arg("Kraków")
  end

  def multiple_args do
    do_multiple_args("Kraków", 12345)
  end

  defp do_single_arg(var1) when is_atom(var1), do: :ok
  defp do_multiple_args(var1, _var2) when is_atom(var1), do: :ok
end
```
```elixir
{:warn_failing_call, {'lib/string_issue.ex', 36}, {:call, [StringIssue, :do_multiple_args, '(\#{#<75>(8, 1, \'integer\', [\'unsigned\', \'big\']), #<114>(8, 1, \'integer\', [\'unsigned\', \'big\']), #<97>(8, 1, \'integer\', [\'unsigned\', \'big\']), #<107>(8, 1, \'integer\', [\'unsigned\', \'big\']), #<195>(8, 1, \'integer\', [\'unsigned\', \'big\']), #<179>(8, 1, \'integer\', [\'unsigned\', \'big\']), #<119>(8, 1, \'integer\', [\'unsigned\', \'big\'])}#,12345)', [1], :only_sig, '(atom(),any())', '\'ok\'', {false, :none}]}}
```
```elixir
"lib/string_issue.ex:36\nThe call StringIssue.do_multiple_args(\"Kraków\", 12345) will never return since it differs in argument:\npositions 1\n\nfrom the success typing arguments:\n(atom(),any())\n.\n"
```
```elixir
defmodule StringIssue do
  def single_arg do
    do_single_arg(<<83, 116, 2>>)
  end

  def multiple_args do
    do_multiple_args(<<83, 116, 2>>, 12345)
  end

  defp do_single_arg(var1) when is_atom(var1), do: :ok
  defp do_multiple_args(var1, _var2) when is_atom(var1), do: :ok
end
```
```elixir
{:warn_failing_call, {'lib/string_issue.ex', 64}, {:call, [StringIssue, :do_multiple_args, '(\#{#<83>(8, 1, \'integer\', [\'unsigned\', \'big\']), #<116>(8, 1, \'integer\', [\'unsigned\', \'big\']), #<2>(8, 1, \'integer\', [\'unsigned\', \'big\'])}#,12345)', [1], :only_sig, '(atom(),any())', '\'ok\'', {false, :none}]}}
```
```elixir
"lib/string_issue.ex:64\nThe call StringIssue.do_multiple_args(<<83, 116, 2>>, 12345) will never return since it differs in argument:\npositions 1\n\nfrom the success typing arguments:\n(atom(),any())\n.\n"
```