### PR TITLE
Fixed issue with elixir var versioning

### DIFF
--- a/lib/dialyxir/pretty_print.ex
+++ b/lib/dialyxir/pretty_print.ex
@@ -80,11 +80,6 @@ defmodule Dialyxir.PrettyPrint do
     |> inspect()
   end
 
-  # TODO: Not sure what the middle value is here.
-  defp do_pretty_print({:atom, _, atom}) do
-    strip_elixir(atom)
-  end
-
   defp do_pretty_print({:atom, atom}) do
     module_name = strip_elixir(atom)
     if module_name == to_string(atom) do
@@ -149,6 +144,12 @@ defmodule Dialyxir.PrettyPrint do
     "#{do_pretty_print(name)} :: #{do_pretty_print(value)}"
   end
 
+  defp do_pretty_print({:name, name}) do
+    name
+    |> to_string()
+    |> strip_var_version()
+  end
+
   defp do_pretty_print({:nil}) do
     "nil"
   end
@@ -189,6 +190,10 @@ defmodule Dialyxir.PrettyPrint do
     string
     |> to_string()
     |> String.trim("Elixir.")
+  end
+
+  defp strip_var_version(var_name) do
+    String.replace(var_name, ~r/^V(.+)@\d+$/, "\\1")
   end
 
   defp struct_name(map_keys) do

--- a/src/struct_parser.yrl
+++ b/src/struct_parser.yrl
@@ -9,7 +9,7 @@ tuple tuple_items
 pattern pattern_items
 byte_list byte_items
 byte
-named_value
+named_value name
 range
 contract
 function.
@@ -52,7 +52,8 @@ value -> byte_list : '$1'.
 value -> '\'' value '|' value '\'' : {pipe_list, '$2', '$4'}.
 value -> value '|' value : {pipe_list, '$1', '$3'}.
 
-named_value -> atom '::' value : {named_value, '$1', '$3'}.
+named_value -> name '::' value : {named_value, '$1', '$3'}.
+name -> atom : {name, unwrap('$1')}.
 
 list -> '(' list_items ')' : {list, paren, '$2'}.
 list -> '[' ']' : {empty_list, square}.


### PR DESCRIPTION
Fixes issues with `Vvar@1`-like var names

Middle value from `{:atom, _, atom}` was probably line number from erlang AST, because atom from named_value wasn't unwrapped.