### PR TITLE
Fix pretty print bug and improve message

### DIFF
--- a/lib/dialyxir/pretty_print.ex
+++ b/lib/dialyxir/pretty_print.ex
@@ -51,6 +51,7 @@ defmodule Dialyxir.PrettyPrint do
   def pretty_print_type(str) do
     prefix = "@spec a("
     suffix = ") :: :ok\ndef a() do\n  :ok\nend"
+    indented_suffix = ") ::\n        :ok\ndef a() do\n  :ok\nend"
     pretty = pretty_print(str)
 
     """
@@ -63,6 +64,7 @@ defmodule Dialyxir.PrettyPrint do
     |> Enum.join("")
     |> String.trim_leading(prefix)
     |> String.trim_trailing(suffix)
+    |> String.trim_trailing(indented_suffix)
     |> String.replace("\n      ", "\n")
   end
 

--- a/lib/dialyxir/warnings/extra_range.ex
+++ b/lib/dialyxir/warnings/extra_range.ex
@@ -30,7 +30,7 @@ defmodule Dialyxir.Warnings.ExtraRange do
     Extra type:
     #{pretty_extra}
 
-    Inferred return type:
+    Success typing:
     #{pretty_signature}
     """
   end

--- a/lib/dialyxir/warnings/extra_range.ex
+++ b/lib/dialyxir/warnings/extra_range.ex
@@ -21,8 +21,18 @@ defmodule Dialyxir.Warnings.ExtraRange do
     pretty_extra = Dialyxir.PrettyPrint.pretty_print_type(extra_ranges)
     pretty_signature = Dialyxir.PrettyPrint.pretty_print_type(signature_range)
 
-    "The specification for #{pretty_module}.#{function}/#{arity} states that the function " <>
-      "might also return #{pretty_extra} but the inferred return is #{pretty_signature}."
+    """
+    Type specification has too many types.
+
+    Function:
+    #{pretty_module}.#{function}/#{arity}
+
+    Extra type:
+    #{pretty_extra}
+
+    Inferred return type:
+    #{pretty_signature}
+    """
   end
 
   @impl Dialyxir.Warning


### PR DESCRIPTION
Some types were not being pretty printed appropriately. This fixes that and improves the extra_rang error message. 

Relates to #118 