### PR TITLE
Allow special chars

### DIFF
--- a/lib/dialyxir/pretty_print.ex
+++ b/lib/dialyxir/pretty_print.ex
@@ -4,9 +4,8 @@ defmodule Dialyxir.PrettyPrint do
       str
       |> to_charlist()
       |> :struct_lexer.string()
-      |> IO.inspect
 
-    {:ok, list} = :struct_parser.parse(tokens)       |> IO.inspect
+    {:ok, list} = :struct_parser.parse(tokens)
 
     list
   end
@@ -19,8 +18,7 @@ defmodule Dialyxir.PrettyPrint do
       |> List.first()
       |> do_pretty_print()
     rescue
-      e ->
-        IO.inspect(e)
+      _ ->
         throw({:error, :parsing, str})
     end
   end

--- a/lib/dialyxir/pretty_print.ex
+++ b/lib/dialyxir/pretty_print.ex
@@ -4,8 +4,9 @@ defmodule Dialyxir.PrettyPrint do
       str
       |> to_charlist()
       |> :struct_lexer.string()
+      |> IO.inspect
 
-    {:ok, list} = :struct_parser.parse(tokens)
+    {:ok, list} = :struct_parser.parse(tokens)       |> IO.inspect
 
     list
   end
@@ -18,7 +19,8 @@ defmodule Dialyxir.PrettyPrint do
       |> List.first()
       |> do_pretty_print()
     rescue
-      _ ->
+      e ->
+        IO.inspect(e)
         throw({:error, :parsing, str})
     end
   end
@@ -91,6 +93,10 @@ defmodule Dialyxir.PrettyPrint do
     "_"
   end
 
+  defp do_pretty_print({:any_function}) do
+    "(... -> any)"
+  end
+
   defp do_pretty_print({:assignment, name, value}) do
     "#{do_pretty_print(name)} = #{do_pretty_print(value)}"
   end
@@ -111,14 +117,6 @@ defmodule Dialyxir.PrettyPrint do
     "_"
   end
 
-  defp do_pretty_print({:atom, ['f', 'a', 'l', 's', 'e']}) do
-    "false"
-  end
-
-  defp do_pretty_print({:atom, ['t', 'r', 'u', 'e']}) do
-    "true"
-  end
-
   defp do_pretty_print({:atom, atom}) do
     atomize(atom)
   end
@@ -129,14 +127,6 @@ defmodule Dialyxir.PrettyPrint do
 
   defp do_pretty_print({:binary_part, value, size}) do
     "#{do_pretty_print(value)} :: #{do_pretty_print(size)}"
-  end
-
-  # TODO: Not sure if this is completely correct. But this seems to line up with actual code.
-  defp do_pretty_print(
-         {:binary,
-          [{:binary_part, {:any}, {:int, 64}}, {:binary_part, {:any}, {:any}, {:size, {:int, 8}}}]}
-       ) do
-    "String.t()"
   end
 
   defp do_pretty_print({:binary, binary_parts}) do
@@ -169,7 +159,7 @@ defmodule Dialyxir.PrettyPrint do
   end
 
   defp do_pretty_print({:int, int}) do
-    "#{int}"
+    "#{to_string(int)}"
   end
 
   defp do_pretty_print({:list, :paren, items}) do
@@ -204,7 +194,6 @@ defmodule Dialyxir.PrettyPrint do
     name
     |> remove_underscores()
     |> to_string()
-    |> strip_var_version()
   end
 
   defp do_pretty_print({nil}) do
@@ -243,30 +232,46 @@ defmodule Dialyxir.PrettyPrint do
     "#{atomize(module)}.#{remove_underscores(type)}()"
   end
 
+  defp do_pretty_print({:type, module, type, inner_type}) do
+    "#{atomize(module)}.#{remove_underscores(type)}(#{do_pretty_print(inner_type)})"
+  end
+
   defp do_pretty_print({:type_list, type, types}) do
     "#{remove_underscores(type)}#{do_pretty_print(types)}"
   end
 
-  defp atomize(atom) do
-    atom = remove_underscores(atom)
-
-    module_name =
-      atom
-      |> Enum.map_join("", &to_string/1)
-      |> strip_elixir()
-      |> strip_var_version()
-
-    if module_name == to_string(atom) do
-      inspect(:"#{module_name}")
-    else
-      "#{module_name}"
-    end
+  defp do_pretty_print({:variable_alias, variable_alias}) do
+    variable_alias
+    |> to_string()
+    |> strip_var_version()
   end
 
-  defp strip_elixir(string) do
-    string
+  defp atomize('\'Elixir.\'' ++ module_name) do
+    to_string(module_name)
+  end
+
+  defp atomize("Elixir." <> module_name) do
+    "#{String.trim(module_name, "'")}"
+  end
+
+  defp atomize(atom) when is_list(atom) do
+    atom
+    |> remove_underscores
     |> to_string()
-    |> String.trim("Elixir.")
+    |> atomize()
+  end
+
+  defp atomize(<< atom >>) when is_number(atom) do
+    "#{atom}"
+  end
+
+  defp atomize(atom) do
+    atom =
+      atom
+      |> to_string()
+      |> String.trim("'")
+
+    inspect(:"#{atom}")
   end
 
   defp strip_var_version(var_name) do
@@ -278,10 +283,10 @@ defmodule Dialyxir.PrettyPrint do
 
     if entry do
       {:map_entry, _, {:atom, struct_name}} = entry
+
       struct_name
-      |> remove_underscores()
-      |> Enum.map_join("", &to_string/1)
-      |> strip_elixir()
+      |> atomize()
+      |> String.trim("\"")
     end
   end
 
@@ -295,9 +300,7 @@ defmodule Dialyxir.PrettyPrint do
     end)
   end
 
-  defp struct_name_entry?(
-         {:map_entry, {:atom, [:_, :_, 's', 't', 'r', 'u', 'c', 't', :_, :_]}, {:atom, _}}
-       ) do
+  defp struct_name_entry?({:map_entry, {:atom, '\'__struct__\''}, {:atom, _}}) do
     true
   end
 

--- a/src/struct_lexer.xrl
+++ b/src/struct_lexer.xrl
@@ -5,7 +5,8 @@ INT = -?[0-9]+
 NUMBERED = _@[0-9]+::
 REST = \.\.\.
 RANGE = \.\.
-ATOM = V.+@[0-9]
+ALIAS = V.+@[0-9]+
+ATOM = \'[^']+\'
 
 Rules.
 
@@ -40,7 +41,8 @@ _ : {token, {'_',  TokenLine}}.
 \= : {token, {'=',  TokenLine}}.
 {RANGE} : {token, {'..', TokenLine}}.
 {INT} : {token, {int,  TokenLine, list_to_integer(TokenChars)}}.
-{ATOM} : {token, {atom_part, TokenLine, TokenChars}}.
+{ALIAS} : {token, {variable_alias, TokenLine, TokenChars}}.
+{ATOM} : {token, {atom_full, TokenLine, TokenChars}}.
 . : {token, {atom_part, TokenLine, TokenChars}}.
 
 Erlang code.

--- a/src/struct_parser.yrl
+++ b/src/struct_parser.yrl
@@ -14,10 +14,11 @@ named_value name
 range
 atom sub_atom
 contract
+alias
 function.
 
 Terminals
-atom_part nil int '(' ')' '_' '\'' ',' '#' '{' '}' '[' ']' 'fun(' '->' ':=' '=>' '|' '..' '::' ':' '...' '<<' '>>' '<' '>' '*' '='.
+variable_alias atom_part atom_full nil int '(' ')' '_' '\'' ',' '#' '{' '}' '[' ']' 'fun(' '->' ':=' '=>' '|' '..' '::' ':' '...' '<<' '>>' '<' '>' '*' '='.
 
 Rootsymbol document.
 
@@ -27,20 +28,22 @@ values -> value : ['$1'].
 values -> value values : ['$1'] ++ '$2'.
 
 value -> atom ':' ':' atom '(' ')' : {type, '$1', '$4'}.
-value -> '\'' atom '\'' ':' atom '(' ')' : {type, '$2', '$5'}.
 value -> atom ':' atom empty_list_paren : {type, '$1', '$3'}.
 value -> '...' : {rest}.
+value -> atom ':' atom '(' value ')' : {type, '$1', '$3', '$5'}.
 value -> atom empty_list_paren : {type, '$1'}.
 value -> atom '(' value ')' : {type, '$1', '$3'}.
 value -> atom list : {type_list, '$1', '$2'}.
 value -> value '=' value : {assignment, '$1', '$3'}.
 value -> '\'' int '..' int '\'' : {range, unwrap('$2'), unwrap('$4')}.
 value -> '\'' int '\'' : {int, unwrap('$2')}.
+value -> int : {int, unwrap('$1')}.
 value -> '\'' atom '\'' : {atom, '$2'}.
 value -> '\'' nil '\''  : {nil}.
 value -> atom : {atom, '$1'}.
 value -> named_value : '$1'.
 value -> list : '$1'.
+value -> alias : '$1'.
 value -> tuple : '$1'.
 value -> pattern : '$1'.
 value -> binary : '$1'.
@@ -53,11 +56,13 @@ value -> map : '$1'.
 value -> '\'' value '|' value '\'' : {pipe_list, '$2', '$4'}.
 value -> value '|' value : {pipe_list, '$1', '$3'}.
 
+atom -> atom_full : unwrap('$1').
 atom -> sub_atom : ['$1'].
 atom -> sub_atom atom : ['$1'] ++ '$2'.
 
+alias -> variable_alias : {variable_alias, unwrap('$1')}.
+
 sub_atom -> atom_part : unwrap('$1').
-sub_atom -> int : unwrap('$1').
 sub_atom -> '_' : '_'.
 
 named_value -> name '::' value : {named_value, '$1', '$3'}.
@@ -98,6 +103,7 @@ map_entry -> value '=>' value : {map_entry, '$1', '$3'}.
 
 range -> int '..' int : {range, unwrap('$1'), unwrap('$3')}.
 
+function -> 'fun(' ')' : {any_function}.
 function -> 'fun(' empty_list_paren '->' value ')' : {function, {args, '$2'}, {return, '$4'}}.
 function -> 'fun(' list '->' value ')' : {function, {args, '$2'}, {return, '$4'}}.
 
@@ -110,7 +116,7 @@ byte_list -> '#' '{' byte_items '}' '#' : {byte_list, '$3'}.
 byte_items -> byte : ['$1'].
 byte_items -> byte ',' byte_items : ['$1'] ++ '$3'.
 
-byte -> '#' '<' int '>' '(' int ',' int ',' '\'' atom '\'' ',' '[' '\'' atom '\'' ',' '\'' atom '\'' ']' ')' : unwrap('$3').
+byte -> '#' '<' int '>' '(' int ',' int ',' atom ',' '[' atom ',' atom ']' ')' : unwrap('$3').
 
 Erlang code.
 

--- a/test/pretty_print_test.exs
+++ b/test/pretty_print_test.exs
@@ -237,25 +237,13 @@ defmodule Dialyxir.Test.PretyPrintTest do
     assert pretty_printed == expected_output
   end
 
-  test "something" do
+  test "any functions are pretty printed appropriately" do
     input = ~S"""
-        (_,
-    'nil' | [{fun(),
-    [any()] | non_neg_integer(),
-    [{_,
-    _}]} | {atom(),
-    atom(),
-    [any()] | non_neg_integer(),
-    [{_,
-    _}]}] | {'Elixir.GenServer',
-    'call',
-    [any(),
-    ...]}) -> binary()
-
+    (_,'nil' | [{fun(),[any()] | non_neg_integer(),[{_,_}]} | {atom(),atom(),[any()] | non_neg_integer(),[{_,_}]}] | {'Elixir.GenServer','call',[any(),...]}) -> binary()
     """
     pretty_printed = Dialyxir.PrettyPrint.pretty_print(input)
 
-    expected_output = "(_,'nil' | [{fun(),[any()] | non_neg_integer(),[{_,_}]} | {atom(),atom(),[any()] | non_neg_integer(),[{_,_}]}] | {'Elixir.GenServer','call',[any(),...]}) -> binary()"
+    expected_output = "(_, nil | [{(... -> any), [any()] | non_neg_integer(), [{_, _}]} | {atom(), atom(), [any()] | non_neg_integer(), [{_, _}]}] | {GenServer, :call, [any(), ...]}) :: binary()"
     assert pretty_printed == expected_output
   end
 

--- a/test/pretty_print_test.exs
+++ b/test/pretty_print_test.exs
@@ -203,11 +203,69 @@ defmodule Dialyxir.Test.PretyPrintTest do
     assert pretty_printed == expected_output
   end
 
-  test "mixed number/atom atoms are parsed" do
+  test "mixed number/atom atoms are pretty printed appropriately" do
     input = ~S"(#{'is_over_13?':=_}) -> 'ok'"
     pretty_printed = Dialyxir.PrettyPrint.pretty_print(input)
 
-    expected_output = "(%{is_over_13? => _}) :: :ok"
+    expected_output = "(%{:is_over_13? => _}) :: :ok"
+    assert pretty_printed == expected_output
+  end
+
+  test "tokenized characters are pretty printed appropriately" do
+    input = ~S"'<' | '<=' | '>' | '>=' | 'fun('"
+    pretty_printed = Dialyxir.PrettyPrint.pretty_print(input)
+
+    expected_output = ":< | :<= | :> | :>= | :\"fun(\""
+    assert pretty_printed == expected_output
+  end
+
+  test "V# names are pretty printed appropriately" do
+    input = ~S"'Elixir.Module.V1.Foo'"
+    pretty_printed = Dialyxir.PrettyPrint.pretty_print(input)
+
+    expected_output = "Module.V1.Foo"
+    assert pretty_printed == expected_output
+    end
+
+  test "integers in maps are pretty printed appropriately" do
+    input = ~S"""
+    #{'source':={[any()] | 98971880 | map()}}
+    """
+    pretty_printed = Dialyxir.PrettyPrint.pretty_print(input)
+
+    expected_output = "%{:source => {[any()] | 98971880 | map()}}"
+    assert pretty_printed == expected_output
+  end
+
+  test "something" do
+    input = ~S"""
+        (_,
+    'nil' | [{fun(),
+    [any()] | non_neg_integer(),
+    [{_,
+    _}]} | {atom(),
+    atom(),
+    [any()] | non_neg_integer(),
+    [{_,
+    _}]}] | {'Elixir.GenServer',
+    'call',
+    [any(),
+    ...]}) -> binary()
+
+    """
+    pretty_printed = Dialyxir.PrettyPrint.pretty_print(input)
+
+    expected_output = "(_,'nil' | [{fun(),[any()] | non_neg_integer(),[{_,_}]} | {atom(),atom(),[any()] | non_neg_integer(),[{_,_}]}] | {'Elixir.GenServer','call',[any(),...]}) -> binary()"
+    assert pretty_printed == expected_output
+  end
+
+  test "inner types are printed appropriately" do
+    input = ~S"""
+    'Elixir.MapSet':t('Elixir.MapSet':t(_))
+    """
+    pretty_printed = Dialyxir.PrettyPrint.pretty_print(input)
+
+    expected_output = "MapSet.t(MapSet.t(_))"
     assert pretty_printed == expected_output
   end
 end

--- a/test/pretty_print_test.exs
+++ b/test/pretty_print_test.exs
@@ -239,11 +239,11 @@ defmodule Dialyxir.Test.PretyPrintTest do
 
   test "any functions are pretty printed appropriately" do
     input = ~S"""
-    (_,'nil' | [{fun(),[any()] | non_neg_integer(),[{_,_}]} | {atom(),atom(),[any()] | non_neg_integer(),[{_,_}]}] | {'Elixir.GenServer','call',[any(),...]}) -> binary()
+    fun()
     """
     pretty_printed = Dialyxir.PrettyPrint.pretty_print(input)
 
-    expected_output = "(_, nil | [{(... -> any), [any()] | non_neg_integer(), [{_, _}]} | {atom(), atom(), [any()] | non_neg_integer(), [{_, _}]}] | {GenServer, :call, [any(), ...]}) :: binary()"
+    expected_output = "(... -> any)"
     assert pretty_printed == expected_output
   end
 


### PR DESCRIPTION
Use more proper lex/parse rules for grabbing atoms. As a result, allows special chars as atoms. Resolves several errors as a result of move and reimplementation of atom, and removes a bunch of less specific code to be more accurate to implementation. 

Relates to #118 

