### PR TITLE
Fix semicolons when printing contracts.

### DIFF
--- a/lib/dialyxir/pretty_print.ex
+++ b/lib/dialyxir/pretty_print.ex
@@ -43,6 +43,38 @@ defmodule Dialyxir.PrettyPrint do
     pretty_print(pattern)
   end
 
+  def pretty_print_contract(str, module, function) do
+    multiple_heads? =
+      str
+      |> to_string()
+      |> String.contains?(";")
+
+    # TODO: This is kind of janky but I've only seen this once.
+    if multiple_heads? do
+      [left, right] =
+        str
+        |> to_string()
+        |> String.split(";")
+
+      left =
+        left
+        |> String.trim_leading(to_string(module))
+        |> String.trim_leading(":")
+        |> String.trim_leading(to_string(function))
+
+      joiner = "Contract head: "
+
+      pretty =
+        [left, right]
+        |> Enum.map(&to_charlist/1)
+        |> Enum.map_join(joiner, &pretty_print_contract/1)
+
+      joiner <> pretty
+    else
+      pretty_print_contract(str)
+    end
+  end
+
   def pretty_print_contract(str) do
     prefix = "@spec a"
     suffix = "\ndef a() do\n  :ok\nend"

--- a/lib/dialyxir/warnings/contract_subtype.ex
+++ b/lib/dialyxir/warnings/contract_subtype.ex
@@ -15,8 +15,8 @@ defmodule Dialyxir.Warnings.ContractSubtype do
   @spec format_long([String.t()]) :: String.t()
   def format_long([module, function, arity, contract, signature]) do
     pretty_module = Dialyxir.PrettyPrint.pretty_print(module)
-    pretty_contract = Dialyxir.PrettyPrint.pretty_print_contract(contract)
     pretty_signature = Dialyxir.PrettyPrint.pretty_print_contract(signature)
+    pretty_contract = Dialyxir.PrettyPrint.pretty_print_contract(contract, module, function)
 
     """
     Type specification is a subtype of the success typing.

--- a/test/pretty_print_test.exs
+++ b/test/pretty_print_test.exs
@@ -265,4 +265,19 @@ defmodule Dialyxir.Test.PretyPrintTest do
     expected_output = "Project.Resources.Components.V1.Actions"
     assert pretty_printed == expected_output
   end
+
+  test "semicolons are pretty printed appropriately" do
+    input = ~S"""
+    'Elixir.Module.V1.Ac(tion.Hel(pers':foo_bar(any(),'nil') -> 'nil'
+    ; ('Elixir.Ecto.Queryable':t(),'Elixir.String':t()) -> 'Elixir.String':t()
+    """
+
+    pretty_printed =
+      input
+      |> to_charlist()
+      |> Dialyxir.PrettyPrint.pretty_print_contract("'Elixir.Module.V1.Ac(tion.Hel(pers'", "foo_bar")
+
+    expected_output = "Contract head: (any(), nil) :: nilContract head: (Ecto.Queryable.t(), String.t()) :: String.t()"
+    assert pretty_printed == expected_output
+  end
 end


### PR DESCRIPTION
Sometimes semicolons are printed. 

Relates to #118 