### PR TITLE
Atoms can be named too. Adds parse rule for them.

### DIFF
--- a/src/dialyzer_parser.yrl
+++ b/src/dialyzer_parser.yrl
@@ -125,6 +125,7 @@ type -> atom '::' list : {named_type, {atom, '$1'}, '$3'}.
 type -> atom '::' map : {named_type, {atom, '$1'}, '$3'}.
 type -> atom '::' tuple : {named_type, {atom, '$1'}, '$3'}.
 type -> atom '::' type : {named_type, {atom, '$1'}, '$3'}.
+type -> atom '::' atom : {named_type, {atom, '$1'}, {atom, '$3'}}.
 type -> atom list : {type_list, '$1', '$2'}.
 
 byte_items -> byte : ['$1'].

--- a/test/pretty_print_test.exs
+++ b/test/pretty_print_test.exs
@@ -346,6 +346,17 @@ defmodule Dialyxir.Test.PretyPrintTest do
     assert pretty_printed == expected_output
   end
 
+  test "named atoms in specs are pretty printed appropriately" do
+    input = ~S"""
+    (Vrules_page_html@1::'nil')
+    """
+
+    pretty_printed = Dialyxir.PrettyPrint.pretty_print(input)
+
+    expected_output = "(rules_page_html :: nil)"
+    assert pretty_printed == expected_output
+  end
+
   test "tuple assigns are pretty printed appropriately" do
     input = ~S"""
     (Vres@1::{'error',_})


### PR DESCRIPTION
Resolves #198