### PR TITLE
Docs: use `--format dialyzer` to create ignore files

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,9 @@ end
 
 Any line of dialyzer output (partially) matching a line in `"dialyzer.ignore-warnings"` is filtered.
 
-For example, in project where `mix dialyzer` outputs:
+Note that copying output in the default format will not work!  Run `mix dialyzer --format dialyzer` to produce output suitable for the ignore file.
+
+For example, in project where `mix dialyzer --format dialyzer` outputs:
 
 ```
   Proceeding with analysis...


### PR DESCRIPTION
When running the current master branch, `mix dialyzer` now creates output (while wonderful for humans!) which does not work when pasting (a single line of) it into the ignore file.  

It works fine if I use `mix dialyzer --format dialyzer` -- so this PR updates the docs to reflect that.