### PR TITLE
Use value instead of listing individual types.

### DIFF
--- a/src/dialyzer_parser.yrl
+++ b/src/dialyzer_parser.yrl
@@ -114,13 +114,7 @@ atom -> atom integer : '$1' ++ ['$2'].
 atom -> atom atom : '$1' ++ '$2'.
 
 type -> atom ':' type : {type, {atom, '$1'}, '$3'}.
-type -> atom '::' atom : {named_type, {atom, '$1'}, {atom, '$3'}}.
-type -> atom '::' binary : {named_type, {atom, '$1'}, '$3'}.
-type -> atom '::' integer : {named_type, {atom, '$1'}, '$3'}.
-type -> atom '::' list : {named_type, {atom, '$1'}, '$3'}.
-type -> atom '::' map : {named_type, {atom, '$1'}, '$3'}.
-type -> atom '::' tuple : {named_type, {atom, '$1'}, '$3'}.
-type -> atom '::' type : {named_type, {atom, '$1'}, '$3'}.
+type -> atom '::' value : {named_type, {atom, '$1'}, '$3'}.
 type -> atom list : {type_list, '$1', '$2'}.
 
 binary_items -> binary_part : ['$1'].


### PR DESCRIPTION
Reduces shift/reduce warnings from 23 to 19, per #182 