### PR TITLE
Bump erlex to 0.1.3

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
   "earmark": {:hex, :earmark, "1.0.2", "a0b0904d74ecc14da8bd2e6e0248e1a409a2bc91aade75fcf428125603de3853", [:mix], []},
-  "erlex": {:hex, :erlex, "0.1.2", "47a26543a8db992d2c6f78bb6ca8d31a784788e5bf9d8b821e020dbacb1e8bdf", [:mix], [], "hexpm"},
+  "erlex": {:hex, :erlex, "0.1.3", "69ccdae8c3667f6acc32fd0773304673d023cb96a3d3f431dad060b73f837741", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
 }


### PR DESCRIPTION
Adds support for empty tuples. Noticed they were missing, though I'm not positive how that data structure is useful in real life. 