### PR TITLE
Add opaque_match explanation and clean up format long/short.

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -41,6 +41,7 @@
   {"lib/dialyxir/warnings/guard_fail_pattern.ex", :no_return},
   {"lib/dialyxir/warnings/improper_list_construction.ex", :no_return},
   {"lib/dialyxir/warnings/invalid_contract.ex", :no_return},
+  {"lib/dialyxir/warnings/opaque_match.ex", :no_return},
   {"lib/dialyxir/warnings/pattern_match.ex", :no_return},
   {"lib/dialyxir/warnings/pattern_match_covered.ex", :no_return},
   {"lib/dialyxir/warnings/race_condition.ex", :no_return},

--- a/lib/dialyxir/warning_helpers.ex
+++ b/lib/dialyxir/warning_helpers.ex
@@ -82,6 +82,6 @@ defmodule Dialyxir.WarningHelpers do
   end
 
   def form_position_string(arg_positions) do
-    Enum.join(arg_positions, " and ")
+    Enum.map_join(arg_positions, " and ", &ordinal/1)
   end
 end

--- a/lib/dialyxir/warnings/opaque_match.ex
+++ b/lib/dialyxir/warnings/opaque_match.ex
@@ -8,28 +8,61 @@ defmodule Dialyxir.Warnings.OpaqueMatch do
   @impl Dialyxir.Warning
   @spec format_short([String.t()]) :: String.t()
   def format_short(_) do
-    "Attempted to match against opaque term."
+    "Attempted to pattern match against the internal structure of an opaque term."
   end
 
   @impl Dialyxir.Warning
   @spec format_long([String.t()]) :: String.t()
   def format_long([pattern, opaque_type, opaque_term]) do
+    pretty_opaque_term = Erlex.pretty_print(opaque_term)
     term =
       if opaque_type == opaque_term do
         "the term"
       else
-        opaque_term
+        pretty_opaque_term
       end
 
-    pretty_pattern = Erlex.pretty_print(pattern)
+    pretty_pattern = Erlex.pretty_print_pattern(pattern)
 
-    "The attempt to match a term of type #{opaque_term} against the #{pretty_pattern} " <>
-      "breaks the opaqueness of #{term}."
+    """
+    Attempted to pattern match against the internal structure of an opaque term.
+
+    Type:
+    #{pretty_opaque_term}
+
+    Pattern:
+    #{pretty_pattern}
+
+    This breaks the opaqueness of #{term}.
+    """
   end
 
   @impl Dialyxir.Warning
   @spec explain() :: String.t()
   def explain() do
-    Dialyxir.Warning.default_explain()
+    """
+    Attempted to pattern match against the internal structure of an opaque term.
+
+    Example:
+
+    defmodule OpaqueStruct do
+      defstruct [:opaque]
+
+      @opaque t :: %__MODULE__{}
+
+      @spec opaque() :: t
+      def opaque() do
+        %__MODULE__{}
+      end
+    end
+
+    defmodule Example do
+      @spec error() :: :error
+      def error() do
+        %{opaque: _} = OpaqueStruct.opaque()
+        :error
+      end
+    end
+    """
   end
 end

--- a/lib/dialyxir/warnings/opaque_match.ex
+++ b/lib/dialyxir/warnings/opaque_match.ex
@@ -15,6 +15,7 @@ defmodule Dialyxir.Warnings.OpaqueMatch do
   @spec format_long([String.t()]) :: String.t()
   def format_long([pattern, opaque_type, opaque_term]) do
     pretty_opaque_term = Erlex.pretty_print(opaque_term)
+
     term =
       if opaque_type == opaque_term do
         "the term"


### PR DESCRIPTION
While debugging I also noticed that the `form_position_string` should be pretty printing the ordinals in its output so I tripped that too. More errors will be forthcoming as I figure out how to trip more opaque things. 