### PR TITLE
Remove instructions for global installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,24 +38,6 @@ end
 mix do deps.get, deps.compile
 ```
 
-To install globally as an archive:
-
-```console
-git clone https://github.com/asummers/erlex
-cd erlex
-mix do compile, archive.build, archive.install
-cd -
-git clone https://github.com/jeremyjh/dialyxir
-cd dialyxir
-MIX_ENV=prod mix do compile, archive.build, archive.install
-```
-or, in Windows:
-```console
-git clone https://github.com/jeremyjh/dialyxir
-cd dialyxir
-set "MIX_ENV=prod" && mix do compile, archive.build, archive.install
-```
-
 ## Usage
 
 Use dialyxir from the directory of the mix project you want to analyze; a PLT file will be created or updated if required and the project will be automatically compiled.


### PR DESCRIPTION
Installing dialyxir globally can cause trouble when working with projects that depend on dialyxir for themself as #273 and #274 have shown.

Also there is this comment by @josevalim suggesting to not promote installing archives too much as well:

https://github.com/elixir-lang/elixir/issues/7577#issuecomment-383300978