### PR TITLE
Gracefully handle error when loading application

### DIFF
--- a/lib/dialyxir/project.ex
+++ b/lib/dialyxir/project.ex
@@ -277,7 +277,7 @@ defmodule Dialyxir.Project do
 
       {:error, err} ->
         nil
-        error("Error loading #{app}, dependency list may be incomplete.\n #{err}")
+        error("Error loading #{app}, dependency list may be incomplete.\n #{inspect(err)}")
     end
 
     case Application.spec(app, :applications) do

--- a/test/dialyxir/project_test.exs
+++ b/test/dialyxir/project_test.exs
@@ -2,7 +2,7 @@ defmodule Dialyxir.ProjectTest do
   alias Dialyxir.Project
 
   use ExUnit.Case
-  import ExUnit.CaptureIO, only: [capture_io: 1]
+  import ExUnit.CaptureIO, only: [capture_io: 1, capture_io: 2]
 
   defp in_project(app, f) when is_atom(app) do
     Mix.Project.in_project(app, "test/fixtures/#{Atom.to_string(app)}", fn _ -> f.() end)
@@ -145,6 +145,13 @@ defmodule Dialyxir.ProjectTest do
 
       lines = Project.filter_legacy_warnings(output_list, pattern)
       assert lines == ["project.ex:9 This should still be here"]
+    end)
+  end
+
+  test "Project with non-existent dependency" do
+    in_project(:nonexistent_deps, fn ->
+      out = capture_io(:stderr, &Project.cons_apps/0)
+      assert Regex.match?(~r/Error loading nonexistent, dependency list may be incomplete/, out)
     end)
   end
 end

--- a/test/fixtures/nonexistent_deps/mix.exs
+++ b/test/fixtures/nonexistent_deps/mix.exs
@@ -1,0 +1,17 @@
+defmodule NonexistentDeps.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :nonexistent_deps, version: "0.1.0", deps: deps()]
+  end
+
+  def application do
+    # This application has a run-time dependency on a non-existent
+    # application.
+    [applications: [:logger, :public_key, :nonexistent]]
+  end
+
+  defp deps do
+    []
+  end
+end


### PR DESCRIPTION
Since Application.load/1 returns errors as tuples, we can't just
interpolate them into the error message, but we need to call "inspect"
first.  Without this change, running dialyxir on an application whose
run-time dependencies cannot be found fails with an error:

    ** (Protocol.UndefinedError) protocol String.Chars not implemented for {'no such file or directory', 'nonexistent.app'}. This protocol is implemented for: Atom, BitString, Date, DateTime, Float, Integer, List, NaiveDateTime, Time, URI, Version, Version.Requirement