### PR TITLE
Change warning message to read properly.

### DIFF
--- a/lib/dialyxir/warning_helpers.ex
+++ b/lib/dialyxir/warning_helpers.ex
@@ -54,8 +54,7 @@ defmodule Dialyxir.WarningHelpers do
       breaks the contract
       #{pretty_contract}
 
-      in argument
-      #{position_string}
+      in #{position_string} argument
       """
     end
   end


### PR DESCRIPTION
Prefer `in 2nd argument` to 

```
in argument
2nd
```