### PR TITLE
Use .beam files after protocol consolidation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,14 @@ language: elixir
 elixir:
   - 1.6.3
   - 1.7.3
+  - 1.8.1
 otp_release:
   - 20.3
   - 21.0
 matrix:
   exclude:
     - elixir: 1.6.3
-    - otp_release: 21.0
+      otp_release: 21.0
 script:
   - mix test --trace
   - MIX_ENV=prod mix do compile --warnings-as-errors, archive.build, archive.install --force

--- a/lib/dialyxir/dialyzer.ex
+++ b/lib/dialyxir/dialyzer.ex
@@ -35,7 +35,7 @@ defmodule Dialyxir.Dialyzer do
         info("Starting Dialyzer")
 
         args
-        |> inspect(label: "dialyzer args", pretty: true)
+        |> inspect(label: "dialyzer args", pretty: true, limit: 10)
         |> info
 
         {duration_ms, result} = :timer.tc(&:dialyzer.run/1, [args])

--- a/lib/dialyxir/dialyzer.ex
+++ b/lib/dialyxir/dialyzer.ex
@@ -35,7 +35,7 @@ defmodule Dialyxir.Dialyzer do
         info("Starting Dialyzer")
 
         args
-        |> inspect(label: "dialyzer args", pretty: true, limit: 10)
+        |> inspect(label: "dialyzer args", pretty: true)
         |> info
 
         {duration_ms, result} = :timer.tc(&:dialyzer.run/1, [args])

--- a/lib/dialyxir/dialyzer.ex
+++ b/lib/dialyxir/dialyzer.ex
@@ -35,7 +35,7 @@ defmodule Dialyxir.Dialyzer do
         info("Starting Dialyzer")
 
         args
-        |> inspect(label: "dialyzer args", pretty: true)
+        |> inspect(label: "dialyzer args", pretty: true, limit: 8)
         |> info
 
         {duration_ms, result} = :timer.tc(&:dialyzer.run/1, [args])

--- a/lib/dialyxir/project.ex
+++ b/lib/dialyxir/project.ex
@@ -61,7 +61,7 @@ defmodule Dialyxir.Project do
     |> Enum.map(fn {_file, path} -> path |> to_charlist() end)
   end
 
-  def dialyzer_paths do
+  defp dialyzer_paths do
     paths = dialyzer_config()[:paths] || default_paths()
     excluded_paths = dialyzer_config()[:excluded_paths] || []
     Enum.map(paths -- excluded_paths, &String.to_charlist/1)
@@ -225,8 +225,8 @@ defmodule Dialyxir.Project do
   end
 
   defp default_paths() do
-    reduce_umbrella_children([], fn paths ->
-      [Mix.Project.compile_path() | [Mix.Project.consolidation_path() | paths]]
+    reduce_umbrella_children([Mix.Project.consolidation_path()], fn paths ->
+      [Mix.Project.compile_path() | paths]
     end)
   end
 

--- a/lib/dialyxir/project.ex
+++ b/lib/dialyxir/project.ex
@@ -52,6 +52,15 @@ defmodule Dialyxir.Project do
     |> Enum.uniq()
   end
 
+  def dialyzer_files do
+    dialyzer_paths()
+    |> Enum.map(fn path ->
+      path |> Path.join("*.beam") |> Path.wildcard() |> Enum.map(&{Path.basename(&1), &1})
+    end)
+    |> Enum.reduce(%{}, fn entries, acc -> Map.merge(acc, Map.new(entries)) end)
+    |> Enum.map(fn {_file, path} -> path |> to_charlist() end)
+  end
+
   def dialyzer_paths do
     paths = dialyzer_config()[:paths] || default_paths()
     excluded_paths = dialyzer_config()[:excluded_paths] || []
@@ -217,7 +226,7 @@ defmodule Dialyxir.Project do
 
   defp default_paths() do
     reduce_umbrella_children([], fn paths ->
-      [Mix.Project.compile_path() | paths]
+      [Mix.Project.compile_path() | [Mix.Project.consolidation_path() | paths]]
     end)
   end
 

--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -252,7 +252,7 @@ defmodule Mix.Tasks.Dialyzer do
     args = [
       {:check_plt, opts[:force_check] || false},
       {:init_plt, String.to_charlist(Project.plt_file())},
-      {:files_rec, Project.dialyzer_paths()},
+      {:files, Project.dialyzer_files()},
       {:warnings, dialyzer_warnings(dargs)},
       {:format, opts[:format]},
       {:raw, opts[:raw]},


### PR DESCRIPTION
Hello! This PR is my proposal for solving #221.
Based on info from here https://github.com/elixir-lang/elixir/issues/7708 I've changed the args for dialyzer and instead of passing directories, I'm passing files list. The list is created in such a way that if files with the same name are present inside `dialyzer_paths()`, only the last one will be passed to the dialyzer. Combine that with consolidation path added by default after the compilation path and the issue seems solved.

A few notes, though:
* I haven't tested it with umbrella projects
* args list for dialyzer becomes enormous, I've added a limit of 10 for args inspection, but maybe some other approach should be taken (e.g. not printing the files at all or only with some flag)