### PR TITLE
Qualify unknown function names.

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,5 +1,5 @@
 [
-  {":0:unknown_function Function t_is_opaque/1 does not exist."},
-  {":0:unknown_function Function t_to_string/1 does not exist."},
+  {":0:unknown_function Function :erl_types.t_is_opaque/1 does not exist."},
+  {":0:unknown_function Function :erl_types.t_to_string/1 does not exist."},
   ~r/format_(long|short).*no local return/
 ]

--- a/lib/dialyxir/warnings/unknown_function.ex
+++ b/lib/dialyxir/warnings/unknown_function.ex
@@ -7,8 +7,9 @@ defmodule Dialyxir.Warnings.UnknownFunction do
 
   @impl Dialyxir.Warning
   @spec format_short({String.t(), String.t(), String.t()}) :: String.t()
-  def format_short({_module, function, arity}) do
-    "Function #{function}/#{arity} does not exist."
+  def format_short({module, function, arity}) do
+    pretty_module = Erlex.pretty_print(module)
+    "Function #{pretty_module}.#{function}/#{arity} does not exist."
   end
 
   @impl Dialyxir.Warning


### PR DESCRIPTION
Also relates to #310.

I neglected to take into account that both unknown types and functions are warned without any file or line number reference. This PR addresses function warnings; Andrew already took care of types.