### PR TITLE
Fix list_unused_filter

### DIFF
--- a/lib/dialyxir/project.ex
+++ b/lib/dialyxir/project.ex
@@ -156,10 +156,13 @@ defmodule Dialyxir.Project do
     dialyzer_config()[:ignore_warnings]
   end
 
-  defp list_unused_filters?(args) do
+  def list_unused_filters?(args) do
     case Keyword.fetch(args, :list_unused_filters) do
-      :error -> dialyzer_config()[:list_unused_filters]
-      {:ok, list_unused_filters} -> list_unused_filters
+      {:ok, list_unused_filters} when not is_nil(list_unused_filters) ->
+        list_unused_filters
+
+      _else ->
+        dialyzer_config()[:list_unused_filters]
     end
   end
 

--- a/test/dialyxir/project_test.exs
+++ b/test/dialyxir/project_test.exs
@@ -168,4 +168,14 @@ defmodule Dialyxir.ProjectTest do
       refute Enum.member?(Project.cons_apps(), :logger)
     end)
   end
+
+  test "list_unused_filters? works as intended" do
+    assert Project.list_unused_filters?(list_unused_filters: true)
+    refute Project.list_unused_filters?(list_unused_filters: nil)
+
+    # Override in mix.exs
+    in_project(:ignore, fn ->
+      assert Project.list_unused_filters?(list_unused_filters: nil)
+    end)
+  end
 end


### PR DESCRIPTION
Configuring list_unused_filter should behave the same as when passing it as a command line argument. If it is not set as a command line argument, the mix setting must be considered.

Fix #313 