### PR TITLE
Fix #314

### DIFF
--- a/lib/dialyxir/formatter.ex
+++ b/lib/dialyxir/formatter.ex
@@ -68,7 +68,7 @@ defmodule Dialyxir.Formatter do
   def format_and_filter(warnings, filterer, filter_map_args, :short) do
     filter_map = filterer.filter_map(filter_map_args)
 
-    {formatted_warnings, _skip_map} = filter_warnings(warnings, filterer, filter_map)
+    {formatted_warnings, filter_map} = filter_warnings(warnings, filterer, filter_map)
 
     formatted_warnings =
       formatted_warnings

--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.Dialyzer do
     * `--force-check`      - force PLT check also if lock file is unchanged.
        useful when dealing with local deps.
     * `--halt-exit-status` - exit immediately with same exit status as dialyzer.
-    * `--list-unused-filters`      - list unused ignore filters
+    * `--list-unused-filters` - list unused ignore filters
       useful for CI. do not use with `mix do`.
     * `--plt`              - only build the required plt(s) and exit.
     *  `--format short`    - format the warnings in a compact format.


### PR DESCRIPTION
In 0f853a2f, the filter map was not reassigned to the updated struct after filtering warnings when the format was set to `short`. This pull request fixes that and adds a test to check that the different formats except for raw have a similar output w.r.t. to listing unused filters.