### PR TITLE
Halt on warnings by default, offer --ignore-exit-status to override.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   - MIX_ENV=prod mix dialyzer --list-unused-filters
   - OUTPUT_TESTS=true mix test
   - MIX_ENV=prod mix dialyzer --format short
-  - MIX_ENV=prod mix dialyzer --format raw
+  - MIX_ENV=prod mix dialyzer --format raw --ignore-exit-status
   - MIX_ENV=prod mix dialyzer --format dialyzer
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   - mix test --trace
   - MIX_ENV=prod mix do compile --warnings-as-errors, archive.build, archive.install --force
   - mix format --check-formatted
-  - MIX_ENV=prod mix dialyzer --list-unused-filters --halt-exit-status
+  - MIX_ENV=prod mix dialyzer --list-unused-filters
   - OUTPUT_TESTS=true mix test
   - MIX_ENV=prod mix dialyzer --format short
   - MIX_ENV=prod mix dialyzer --format raw

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: elixir
 elixir:
-  - 1.6.3
   - 1.7.3
   - 1.8.1
 otp_release:
@@ -8,7 +7,6 @@ otp_release:
   - 21.3
 matrix:
   exclude:
-    - elixir: 1.6.3
       otp_release: 21.3
 script:
   - mix test --trace

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - MIX_ENV=prod mix dialyzer --list-unused-filters
   - OUTPUT_TESTS=true mix test
   - MIX_ENV=prod mix dialyzer --format short
-  - MIX_ENV=prod mix dialyzer --format raw --ignore-exit-status
+  - MIX_ENV=prod mix dialyzer --format raw
   - MIX_ENV=prod mix dialyzer --format dialyzer
 branches:
   except:

--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ mix dialyzer
 
   * `--no-compile`         - do not compile even if needed.
   * `--no-check`           - do not perform (quick) check to see if PLT needs updated.
-  * `--halt-exit-status`   - exit immediately with same exit status as dialyzer.
-    useful for CI. do not use with `mix do`.
+  * `--ignore-exit-status` - display warnings but do not halt the VM or return an exit status code
   *  `--format short`      - format the warnings in a compact format.
   *  `--format raw`        - format the warnings in format returned before Dialyzer formatting
   *  `--format dialyxir`   - format the warnings in a pretty printed format

--- a/lib/dialyxir/dialyzer.ex
+++ b/lib/dialyxir/dialyzer.ex
@@ -6,12 +6,12 @@ defmodule Dialyxir.Dialyzer do
   alias Dialyxir.FilterMap
 
   defmodule Runner do
-    @dialyxir_args ~w(
-      raw
-      format
-      list_unused_filters
-      ignore_exit_status
-    )a
+    @dialyxir_args [
+      :raw,
+      :format,
+      :list_unused_filters,
+      :ignore_exit_status
+    ]
 
     def run(args, filterer) do
       try do

--- a/lib/dialyxir/dialyzer.ex
+++ b/lib/dialyxir/dialyzer.ex
@@ -6,10 +6,16 @@ defmodule Dialyxir.Dialyzer do
   alias Dialyxir.FilterMap
 
   defmodule Runner do
+    @dialyxir_args ~w(
+      raw
+      format
+      list_unused_filters
+      ignore_exit_status
+    )a
+
     def run(args, filterer) do
       try do
-        split_args = [:raw, :format, :list_unused_filters, :halt_exit_status]
-        {split, args} = Keyword.split(args, split_args)
+        {split, args} = Keyword.split(args, @dialyxir_args)
 
         formatter =
           cond do

--- a/lib/dialyxir/filter_map.ex
+++ b/lib/dialyxir/filter_map.ex
@@ -10,10 +10,10 @@ defmodule Dialyxir.FilterMap do
   @doc """
   Fill a `FilterMap` from an ignore file.
   """
-  def from_file(ignore_file, list_unused_filters?, halt_exit_status?) do
+  def from_file(ignore_file, list_unused_filters?, ignore_exit_status?) do
     filter_map = %__MODULE__{
       list_unused_filters?: list_unused_filters?,
-      unused_filters_as_errors?: list_unused_filters? && halt_exit_status?
+      unused_filters_as_errors?: list_unused_filters? && !ignore_exit_status?
     }
 
     {ignore, _} =
@@ -30,7 +30,7 @@ defmodule Dialyxir.FilterMap do
   Remove all non-allowed arguments from `args`.
   """
   def to_args(args) do
-    Keyword.take(args, [:list_unused_filters, :halt_exit_status])
+    Keyword.take(args, [:list_unused_filters, :ignore_exit_status])
   end
 
   @doc """

--- a/lib/dialyxir/project.ex
+++ b/lib/dialyxir/project.ex
@@ -121,7 +121,7 @@ defmodule Dialyxir.Project do
       true ->
         ignore_file = dialyzer_ignore_warnings() || default_ignore_warnings()
 
-        FilterMap.from_file(ignore_file, list_unused_filters?(args), halt_exit_status?(args))
+        FilterMap.from_file(ignore_file, list_unused_filters?(args), ignore_exit_status?(args))
     end
   end
 
@@ -187,8 +187,8 @@ defmodule Dialyxir.Project do
     end
   end
 
-  defp halt_exit_status?(args) do
-    args[:halt_exit_status]
+  defp ignore_exit_status?(args) do
+    args[:ignore_exit_status]
   end
 
   def elixir_plt() do

--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -141,11 +141,11 @@ defmodule Mix.Tasks.Dialyzer do
   ]
 
   @command_options Keyword.merge(@old_options,
-                     no_compile: :boolean,
-                     no_check: :boolean,
                      force_check: :boolean,
                      ignore_exit_status: :boolean,
                      list_unused_filters: :boolean,
+                     no_check: :boolean,
+                     no_compile: :boolean,
                      plt: :boolean,
                      quiet: :boolean,
                      raw: :boolean,
@@ -273,7 +273,7 @@ defmodule Mix.Tasks.Dialyzer do
 
     unless exit_status == 0 || opts[:ignore_exit_status] do
       error("Halting VM with exit status #{exit_status}")
-      :erlang.halt(exit_status)
+      System.halt(exit_status)
     end
   end
 

--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -271,7 +271,7 @@ defmodule Mix.Tasks.Dialyzer do
     report = if status == :ok, do: &info/1, else: &error/1
     Enum.each(result, report)
 
-    unless opts[:ignore_exit_status] do
+    unless exit_status == 0 || opts[:ignore_exit_status] do
       info("Halting VM with exit status #{exit_status}")
       :erlang.halt(exit_status)
     end

--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -272,7 +272,7 @@ defmodule Mix.Tasks.Dialyzer do
     Enum.each(result, report)
 
     unless exit_status == 0 || opts[:ignore_exit_status] do
-      info("Halting VM with exit status #{exit_status}")
+      error("Halting VM with exit status #{exit_status}")
       :erlang.halt(exit_status)
     end
   end


### PR DESCRIPTION
resolves #315 

Implements the suggestions from #315. Halting with a non-zero RC is now the default behavior with an `--ignore-exit-status` option that prevents a halt. When halting, an extra informational message is written. There is no halt if there are no warnings.

![image](https://user-images.githubusercontent.com/90510/56444894-b91a4a80-62c8-11e9-8e3a-ba859315c159.png)

Also, there is a warning if the old `--halt-exit-status` option is provided. 

Right now it looks like this:

![image](https://user-images.githubusercontent.com/90510/56444992-18785a80-62c9-11e9-8cb4-31c05dad602f.png)

