### PR TITLE
Fix OptionParser deprecation warning on `mix dialyzer.explain`

### DIFF
--- a/lib/mix/tasks/dialyzer/explain.ex
+++ b/lib/mix/tasks/dialyzer/explain.ex
@@ -19,7 +19,7 @@ defmodule Mix.Tasks.Dialyzer.Explain do
   alias Dialyxir.Output
 
   def run(args) do
-    case OptionParser.parse(args) do
+    case OptionParser.parse(args, strict: []) do
       {_, [warning], _} ->
         warning |> explanation_text() |> Output.info()
 


### PR DESCRIPTION
This fixes a deprecation warning when calling `mix dialyzer.explain`.

```shell
➜ mix dialyzer.explain invalid_contract
warning: not passing the :switches or :strict option to OptionParser is deprecated
  (elixir) lib/option_parser.ex:607: OptionParser.build_config/1
  (elixir) lib/option_parser.ex:231: OptionParser.parse/2
  lib/mix/tasks/dialyzer/explain.ex:22: Mix.Tasks.Dialyzer.Explain.run/1
  (mix) lib/mix/task.ex:331: Mix.Task.run_task/3
  (mix) lib/mix/cli.ex:79: Mix.CLI.run_task/2

The @spec for the function does not match the success typing of
the function.

Example:

defmodule Example do
  @spec process(:error) :: :ok
  def process(:ok) do
    :ok
  end
end

The @spec in this case claims that the function accepts a parameter :error
but the function head only accepts :ok, resulting in the mismatch.
```