### PR TITLE
OTP 22 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ elixir:
 otp_release:
   - 20.3
   - 21.3
-matrix:
-  exclude:
-      otp_release: 21.3
+  - 22.0
 script:
   - mix test --trace
   - MIX_ENV=prod mix do compile --warnings-as-errors, archive.build, archive.install --force

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
   - MIX_ENV=prod mix dialyzer --format short
   - MIX_ENV=prod mix dialyzer --format raw
   - MIX_ENV=prod mix dialyzer --format dialyzer
+  - MIX_ENV=examples mix dialyzer --format short --ignore-exit-status
 branches:
   except:
     - /^[0-9]\.[0-9]/

--- a/lib/dialyxir/formatter.ex
+++ b/lib/dialyxir/formatter.ex
@@ -50,8 +50,15 @@ defmodule Dialyxir.Formatter do
   end
 
   defp format_warning(warning, :dialyzer) do
+    # OTP 22 uses indented output, but that's incompatible with dialyzer.ignore-warnings format.
+    # Can be disabled, but OTP 21 and older only accept an atom, so only disable on OTP 22+.
+    opts =
+      if String.to_integer(System.otp_release()) < 22,
+        do: :fullpath,
+        else: [{:filename_opt, :fullpath}, {:indent_opt, false}]
+
     warning
-    |> :dialyzer.format_warning(:fullpath)
+    |> :dialyzer.format_warning(opts)
     |> String.Chars.to_string()
     |> String.replace_trailing("\n", "")
   end

--- a/lib/dialyxir/warnings.ex
+++ b/lib/dialyxir/warnings.ex
@@ -21,7 +21,7 @@ defmodule Dialyxir.Warnings do
                 Dialyxir.Warnings.ContractWithOpaque,
                 Dialyxir.Warnings.ExactEquality,
                 Dialyxir.Warnings.ExtraRange,
-                Dialyxir.Warnings.FuncionApplicationArguments,
+                Dialyxir.Warnings.FunctionApplicationArguments,
                 Dialyxir.Warnings.FunctionApplicationNoFunction,
                 Dialyxir.Warnings.GuardFail,
                 Dialyxir.Warnings.GuardFailPattern,

--- a/lib/dialyxir/warnings/function_application_arguments.ex
+++ b/lib/dialyxir/warnings/function_application_arguments.ex
@@ -1,4 +1,4 @@
-defmodule Dialyxir.Warnings.FuncionApplicationArguments do
+defmodule Dialyxir.Warnings.FunctionApplicationArguments do
   @behaviour Dialyxir.Warning
 
   @impl Dialyxir.Warning

--- a/lib/dialyxir/warnings/function_application_arguments.ex
+++ b/lib/dialyxir/warnings/function_application_arguments.ex
@@ -12,6 +12,11 @@ defmodule Dialyxir.Warnings.FuncionApplicationArguments do
     "Function application with #{pretty_args} will fail."
   end
 
+  # OTP 22+ format
+  def format_short([_arg_positions, args, type]) do
+    format_short([args, type])
+  end
+
   @impl Dialyxir.Warning
   @spec format_long([String.t()]) :: String.t()
   def format_long([args, type]) do
@@ -20,6 +25,27 @@ defmodule Dialyxir.Warnings.FuncionApplicationArguments do
 
     "Function application with arguments #{pretty_args} will fail " <>
       "since the function has type #{pretty_type}."
+  end
+
+  # OTP 22+ format
+  def format_long([arg_positions, args, type]) do
+    pretty_arg_positions = form_positions(arg_positions)
+    pretty_args = Erlex.pretty_print_args(args)
+    pretty_type = Erlex.pretty_print(type)
+
+    "Function application with arguments #{pretty_args} will fail " <>
+      "since the function has type #{pretty_type}, " <>
+      "which differs in #{pretty_arg_positions}."
+  end
+
+  defp form_positions(arg_positions = [_]) do
+    form_position_string = Dialyxir.WarningHelpers.form_position_string(arg_positions)
+    "the #{form_position_string} argument"
+  end
+
+  defp form_positions(arg_positions) do
+    form_position_string = Dialyxir.WarningHelpers.form_position_string(arg_positions)
+    "the #{form_position_string} arguments"
   end
 
   @impl Dialyxir.Warning

--- a/test/dialyxir/formatter_test.exs
+++ b/test/dialyxir/formatter_test.exs
@@ -93,6 +93,18 @@ defmodule Dialyxir.FormatterTest do
     end
   end
 
+  describe "simple string ignore" do
+    test "evaluates an ignore file and ignores warnings matching the pattern" do
+      warning =
+        {:warn_matching, {'a/file.ex', 17}, {:pattern_match, ['pattern \'ok\'', '\'error\'']}}
+
+      in_project(:ignore_string, fn ->
+        assert Formatter.format_and_filter([warning], Project, [], :dialyzer) ==
+                 {:ok, [], :no_unused_filters}
+      end)
+    end
+  end
+
   test "listing unused filter behaves the same for different formats" do
     warnings = [
       {:warn_return_no_exit, {'a/regex_file.ex', 17},

--- a/test/examples/function_app_args.ex
+++ b/test/examples/function_app_args.ex
@@ -1,0 +1,10 @@
+defmodule Dialyxir.Examples.FunctionApplicationArgs do
+  def f do
+    fn :a, [] -> :ok end
+  end
+
+  def ok() do
+    fun = f()
+    fun.(:b, [])
+  end
+end

--- a/test/fixtures/ignore_string/dialyzer.ignore-warnings
+++ b/test/fixtures/ignore_string/dialyzer.ignore-warnings
@@ -1,0 +1,1 @@
+a/file.ex:17: The pattern 'ok' can never match the type 'error'

--- a/test/fixtures/ignore_string/mix.exs
+++ b/test/fixtures/ignore_string/mix.exs
@@ -1,0 +1,14 @@
+defmodule IgnoreString.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :ignore_string,
+      version: "0.1.0",
+      dialyzer: [
+        ignore_warnings: "dialyzer.ignore-warnings",
+        list_unused_filters: true
+      ]
+    ]
+  end
+end


### PR DESCRIPTION
* reenable travis tests on OTP 21.3
* enable travis tests on OTP 22.0
* disable indenting in dialyzer format to keep old `dialyzer.ignore-warnings` files working
* fix formatting of `fun_app_args` results (OTP 22 changed the raw format)

See individual commit messages for details.