### PR TITLE
Fix mix task's options alignment

### DIFF
--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -16,11 +16,11 @@ defmodule Mix.Tasks.Dialyzer do
     * `--list-unused-filters` - list unused ignore filters
       useful for CI. do not use with `mix do`.
     * `--plt`              - only build the required plt(s) and exit.
-    *  `--format short`    - format the warnings in a compact format.
-    *  `--format raw`      - format the warnings in format returned before Dialyzer formatting
-    *  `--format dialyxir` - format the warnings in a pretty printed format
-    *  `--format dialyzer` - format the warnings in the original Dialyzer format
-    *  `--quiet`           - suppress all informational messages
+    * `--format short`     - format the warnings in a compact format.
+    * `--format raw`       - format the warnings in format returned before Dialyzer formatting
+    * `--format dialyxir`  - format the warnings in a pretty printed format
+    * `--format dialyzer`  - format the warnings in the original Dialyzer format
+    * `--quiet`            - suppress all informational messages
 
   Warning flags passed to this task are passed on to `:dialyzer`.
 


### PR DESCRIPTION
A really trivial fix that removes the extra spaces that make options listing not aligned.