### PR TITLE
Fix one format mention in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ end
 
 #### Explanations
 
-Explanations are available for classes of warnings by passing the `--explain warning_name` flag. It will include a description about the type of warning, as well as a small example that would also cause that warning. Poor explanations and examples should be considered issues in this library, and pull requests are very welcome! The warning name is returned from the `--format short` and `--format dialyzer` flags. List available warnings with `--list`.
+Explanations are available for classes of warnings by passing the `--explain warning_name` flag. It will include a description about the type of warning, as well as a small example that would also cause that warning. Poor explanations and examples should be considered issues in this library, and pull requests are very welcome! The warning name is returned from the `--format short` and `--format raw` flags. List available warnings with `--list`.
 
 #### Formats
 


### PR DESCRIPTION
The `dialyzer` format doesn't include warning names but `raw` does.