### PR TITLE
Add exclude files config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,26 @@ def project do
 end
 ```
 
+You can also exclude specific files with :excluded_file_suffixes keyword, when excluding whole paths is not precise enough.
+```elixir
+def project do
+  [
+    app: :my_app,
+    version: "0.0.1",
+    deps: deps,
+    dialyzer: [
+      plt_add_apps: [:mnesia],
+      flags: [:unmatched_returns, :error_handling, :race_conditions, :no_opaque],
+      excluded_file_suffixes: [
+        "_build/dev/lib/dialyxir/ebin/Elixir.Dialyxir.Project.beam",
+        "lib/dialyxir/ebin/Elixir.Dialyxir.Project.beam",
+        "Elixir.Dialyxir.Warnings.NoReturn.beam"
+      ]
+    ]
+  ]
+end
+```
+
 ### Ignore Warnings
 
 By default `dialyxir` has always included the `:unknown` warning option so that warnings about unknown functions are returned. This is usually a clue that the PLT is not complete and it may be best to leave it on, but it can be disabled entirely by specifying `remove_defaults: [:unknown]` in your config.

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ end
 
 ### Paths
 
-By default only the ebin in the `_build` directory for the current mix environment of your project is included in paths to search for BEAM files to perform analysis on. You can specify a list of locations to find BEAMS for analysis with :paths keyword.
+By default only the ebin in the `_build` directory for the current mix environment of your project is included in paths to search for BEAM files to perform analysis on. You can specify a list of locations to find BEAMS for analysis with :paths or exclude certain paths with :excluded_paths keyword.
 
 ```elixir
 def project do
@@ -213,7 +213,8 @@ def project do
     dialyzer: [
       plt_add_apps: [:mnesia],
       flags: [:unmatched_returns, :error_handling, :race_conditions, :no_opaque],
-      paths: ["_build/dev/lib/my_app/ebin", "_build/dev/lib/foo/ebin"]
+      paths: ["_build/dev/lib/my_app/ebin", "_build/dev/lib/foo/ebin"],
+      excluded_paths: ["_build/dev/lib/bar/ebin"]
     ]
   ]
 end

--- a/lib/dialyxir/project.ex
+++ b/lib/dialyxir/project.ex
@@ -77,7 +77,7 @@ defmodule Dialyxir.Project do
 
     Enum.reject(files, fn file ->
       Enum.any?(file_exclusions, fn exclusion ->
-        String.match?(file, ~r/#{exclusion}$/)
+        String.ends_with?(file, exclusion)
       end)
     end)
   end

--- a/lib/dialyxir/project.ex
+++ b/lib/dialyxir/project.ex
@@ -67,7 +67,19 @@ defmodule Dialyxir.Project do
 
     beam_files
     |> Map.merge(consolidated_files)
-    |> Enum.map(fn {_file, path} -> path |> to_charlist() end)
+    |> Enum.map(fn {_file, path} -> path end)
+    |> reject_excluded_files()
+    |> Enum.map(&to_charlist(&1))
+  end
+
+  defp reject_excluded_files(files) do
+    file_exclusions = dialyzer_config()[:excluded_file_suffixes] || []
+
+    Enum.reject(files, fn file ->
+      Enum.any?(file_exclusions, fn exclusion ->
+        String.match?(file, ~r/#{exclusion}$/)
+      end)
+    end)
   end
 
   defp dialyzer_paths do


### PR DESCRIPTION
This adds a configurable `:exclude_file_suffixes` parameter that can be used to exclude certain .beam files.
It also updates the README and adds a reference to both the existing `:exclude_paths` and the new `:exclude_file_suffixes` param.

Not so sure about testing this, since it is tightly coupled to `dializer_files/0` which directly reads files from the file system 🤔 