### PR TITLE
Fix exception when short format fails.

### DIFF
--- a/lib/dialyxir/formatter.ex
+++ b/lib/dialyxir/formatter.ex
@@ -205,10 +205,18 @@ defmodule Dialyxir.Formatter do
   defp filter_warning(filterer, warning = {_, {file, line}, {warning_type, _}}, filter_map) do
     if Map.has_key?(Dialyxir.Warnings.warnings(), warning_type) do
       {skip?, matching_filters} =
-        filterer.filter_warning?(
-          {to_string(file), warning_type, line, format_warning(warning, :short)},
-          filter_map
-        )
+        try do
+          filterer.filter_warning?(
+            {to_string(file), warning_type, line, format_warning(warning, :short)},
+            filter_map
+          )
+        rescue
+          _ ->
+            {false, []}
+        catch
+          _ ->
+            {false, []}
+        end
 
       filter_map =
         Enum.reduce(matching_filters, filter_map, fn filter, filter_map ->


### PR DESCRIPTION
Closes #383 

As an aside: The code around here is really awkward. Why do we accept alternate `filterer`s? Why is it s `?` function that returns things other than boolean? And more awkwardly, why is that contract returning both the data AND a function over that data in the `skip?` variable (just checking its emptiness)? 