### PR TITLE
Improve handling of local dependencies

### DIFF
--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -11,7 +11,6 @@ defmodule Mix.Tasks.Dialyzer do
     * `--no-compile`       - do not compile even if needed.
     * `--no-check`         - do not perform (quick) check to see if PLT needs update.
     * `--force-check`      - force PLT check also if lock file is unchanged.
-       useful when dealing with local deps.
     * `--ignore-exit-status` - display warnings but do not halt the VM or return an exit status code
     * `--list-unused-filters` - list unused ignore filters
       useful for CI. do not use with `mix do`.
@@ -161,7 +160,7 @@ defmodule Mix.Tasks.Dialyzer do
     if Mix.Project.get() do
       Project.check_config()
 
-      unless opts[:no_compile], do: Mix.Project.compile([])
+      unless opts[:no_compile], do: Mix.Task.run("compile", [])
 
       _ =
         unless no_check?(opts) do


### PR DESCRIPTION
Treat all path dependencies as files in the current
project instead of remote dependencies. This simplifies
the logic as we no longer need to especially handle
umbrella applications, as they are all path dependencies
anyway.

This requires Elixir v1.10+.

Also note this patch completely removes `:plt_add_deps`
because it did not work before. Since the `Plt.check/2`
function always adds all transitive dependencies, any
attempt to discard deps by setting `:plt_add_deps` to
`:apps_deps` had no effect. This PR does not remove
`:apps_deps` from the documentation but I would
recommend so to be done.