### PR TITLE
Remove nesting from warning and do not return self() on start

### DIFF
--- a/lib/dialyxir.ex
+++ b/lib/dialyxir.ex
@@ -5,14 +5,14 @@ defmodule Dialyxir do
 
   def start(_, _) do
     Output.info("""
-      Warning: the `dialyxir` application's start function was called, which likely means you
-      did not add the dependency with the `runtime: false` flag. This is not recommended because
-      it will mean that unnecessary applications are started, and unnecessary applications are most
-      likely being added to your PLT file, increasing build time.
-      Please add `runtime: false` in your `mix.exs` dependency section e.g.:
-      {:dialyxir, "~> 0.5", only: [:dev], runtime: false}
+    Warning: the `dialyxir` application's start function was called, which likely means you
+    did not add the dependency with the `runtime: false` flag. This is not recommended because
+    it will mean that unnecessary applications are started, and unnecessary applications are most
+    likely being added to your PLT file, increasing build time.
+    Please add `runtime: false` in your `mix.exs` dependency section e.g.:
+    {:dialyxir, "~> 0.5", only: [:dev], runtime: false}
     """)
 
-    {:ok, self()}
+    Supervisor.start_link([], strategy: :one_for_one)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule Dialyxir.Mixfile do
       description: description(),
       package: package(),
       deps: deps(),
+      aliases: [test: "test --no-start"],
       dialyzer: [
         plt_apps: [:dialyzer, :elixir, :kernel, :mix, :stdlib, :erlex],
         ignore_warnings: ".dialyzer_ignore.exs",


### PR DESCRIPTION
Erlang/OTP requires a separate supervisor process to
be returned from the start/2 callback. Otherwise this
may cause issues in tools like Observer, LiveDashboard,
etc.