### PR TITLE
exclude files based on regex; https://github.com/jeremyjh/dialyxir/pull/382

### DIFF
--- a/lib/dialyxir/project.ex
+++ b/lib/dialyxir/project.ex
@@ -83,9 +83,7 @@ defmodule Dialyxir.Project do
 
           case result do
             {:match, _captured} -> true
-            :match -> true
             :nomatch -> false
-            {:error, _err_type} -> false
           end
         end,
         file_exclusions

--- a/lib/dialyxir/project.ex
+++ b/lib/dialyxir/project.ex
@@ -67,7 +67,30 @@ defmodule Dialyxir.Project do
 
     beam_files
     |> Map.merge(consolidated_files)
-    |> Enum.map(fn {_file, path} -> path |> to_charlist() end)
+    |> Enum.map(fn {_file, path} -> path end)
+    |> reject_exclude_files()
+    |> Enum.map(&to_charlist(&1))
+  end
+
+  defp reject_exclude_files(files) do
+    file_exclusions = dialyzer_config()[:exclude_files] || []
+
+    Enum.reject(files, fn file ->
+      :lists.any(
+        fn reject_file_pattern ->
+          re = <<reject_file_pattern::binary, "$">>
+          result = :re.run(file, re)
+
+          case result do
+            {:match, _captured} -> true
+            :match -> true
+            :nomatch -> false
+            {:error, _err_type} -> false
+          end
+        end,
+        file_exclusions
+      )
+    end)
   end
 
   defp dialyzer_paths do


### PR DESCRIPTION
Adds a exclude_files config that works off regex, example:

```elixir
  def project do
    [
      dialyzer: [
        plt_file: {:no_warn, "priv/plts/dialyzer.plt"},
        ignore_warnings: ".dialyzer_ignore.exs",
        exclude_files: [
          "(.*)Elixir.Table.(.*)"
        ]
      ],
    ]
  end
```