### PR TITLE
doc: Improve message verbiage

### DIFF
--- a/lib/dialyxir/warning_helpers.ex
+++ b/lib/dialyxir/warning_helpers.ex
@@ -24,8 +24,8 @@ defmodule Dialyxir.WarningHelpers do
       positions = form_position_string(arg_positions)
 
       """
-      will never return since it differs in arguments with
-      positions #{positions} from the success typing arguments:
+      will never return since the #{positions} arguments differ
+      from the success typing arguments:
 
       #{pretty_signature_args}
       """


### PR DESCRIPTION
Previous message was:

```
will never return since it differs in arguments with
positions 1st and 2nd from the success typing arguments:
```

Now reads:

```
will never return since the 1st and 2nd arguments differ 
from the success typing arguments:
```