### PR TITLE
Added a configuration option to specify the path of the project plt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Running the mix task `dialyzer` by default builds several PLT files:
   * A project environment specific file in _build/env/dialyze_erlang-[OTP Version]_elixir-[Elixir Version]_deps-dev.plt
 
 The core files are simply copied to your project folder when you run `dialyxir` for the first time with a given version of Erlang and Elixir. By default, all
-the modules in the project PLT are checked against your dependencies to be sure they are up to date. If you do not want to use MIX_HOME to store your core Erlang and Elixir files, you can provide a :plt_core_path key with a file path. You can specify a different location for the project PLT file with the :plt_file keyword - this is deprecated because people were using it with the old `dialyxir` to have project-specific PLTs, which are now the default. To silence the deprecation warning, specify this value as `plt_file: {:no_warn, "/myproject/mypltfile"}`.
+the modules in the project PLT are checked against your dependencies to be sure they are up to date. If you do not want to use MIX_HOME to store your core Erlang and Elixir files, you can provide a :plt_core_path key with a file path. You can specify a different directory for the project PLT file with the :plt_local_path keyword. You can specify a different filename for the project PLT file with the :plt_file keyword - this is deprecated because people were using it with the old `dialyxir` to have project-specific PLTs, which are now the default. To silence the deprecation warning, specify this value as `plt_file: {:no_warn, "/myproject/mypltfile"}`.
 
 The core PLTs include a basic set of OTP applications, as well as all of the Elixir standard libraries.
 The apps included by default are `[ :erts, :kernel, :stdlib, :crypto]`.

--- a/lib/dialyxir/project.ex
+++ b/lib/dialyxir/project.ex
@@ -258,8 +258,10 @@ defmodule Dialyxir.Project do
   defp core_path(), do: dialyzer_config()[:plt_core_path] || Mix.Utils.mix_home()
 
   defp local_plt(name) do
-    Path.join(Mix.Project.build_path(), "dialyxir_" <> name <> ".plt")
+    Path.join(local_path(), "dialyxir_" <> name <> ".plt")
   end
+
+  defp local_path(), do: dialyzer_config()[:plt_local_path] || Mix.Project.build_path()
 
   defp default_paths() do
     reduce_umbrella_children([], fn paths ->

--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -83,6 +83,8 @@ defmodule Mix.Tasks.Dialyzer do
 
   * `dialyzer: :plt_file` - Deprecated - specify the plt file name to create and use - default is to create one in the project's current build environmnet (e.g. _build/dev/) specific to the Erlang/Elixir version used. Note that use of this key in version 0.4 or later will produce a deprecation warning - you can silence the warning by providing a pair with key :no_warn e.g. `plt_file: {:no_warn,"filename"}`.
 
+  * `dialyzer: :plt_local_path` - specify the plt directory name to create and use - default is the project's current build environmnet (e.g. _build/dev/).
+
   * `dialyzer: :plt_core_path` - specify an alternative to MIX_HOME to use to store the Erlang and Elixir core files.
 
   * `dialyzer: :ignore_warnings` - specify file path to filter well-known warnings.

--- a/test/dialyxir/project_test.exs
+++ b/test/dialyxir/project_test.exs
@@ -16,7 +16,13 @@ defmodule Dialyxir.ProjectTest do
 
   test "Default Project PLT File in _build dir" do
     in_project(:default_apps, fn ->
-      assert Regex.match?(~r/_build.*plt/, Project.plt_file())
+      assert Regex.match?(~r/_build\/.*plt/, Project.plt_file())
+    end)
+  end
+
+  test "Can specify a different local PLT path" do
+    in_project(:alt_local_path, fn ->
+      assert Regex.match?(~r/dialyzer\/.*plt/, Project.plt_file())
     end)
   end
 

--- a/test/fixtures/alt_local_path/mix.exs
+++ b/test/fixtures/alt_local_path/mix.exs
@@ -1,0 +1,7 @@
+defmodule AltLocalPath.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :alt_local_path, version: "1.0.0", dialyzer: [plt_local_path: "dialyzer"]]
+  end
+end


### PR DESCRIPTION
This is helpful if you want to move the dialyxir plt files into their own directory (in my case, this is helpful for running dialyxir inside of docker with caching), but don't want to mess with the naming of the plt files.