### PR TITLE
Add `ignore_file` format output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,11 @@ jobs:
       env:
         MIX_ENV: prod
 
+    - name: Get results in ignore_file format
+      run: mix dialyzer --format ignore_file
+      env:
+        MIX_ENV: prod
+
     - name: Check examples
       run: mix dialyzer --format short --ignore-exit-status
       env:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ mix dialyzer
   *  `--format raw`        - format the warnings in format returned before Dialyzer formatting
   *  `--format dialyxir`   - format the warnings in a pretty printed format
   *  `--format dialyzer`   - format the warnings in the original Dialyzer format
+  *  `--format ignore_file` - format the warnings to be suitable for adding to "Elixir Term Format" ignore file
   *  `--quiet`             - suppress all informational messages
 
 Warning flags passed to this task are passed on to `:dialyzer` - e.g.
@@ -289,8 +290,8 @@ done (warnings were emitted)
 
 #### Elixir Term Format
 
-Dialyxir also recognizes an Elixir format of the ignore file. If your ignore file is an `exs` file, Dialyxir will evaluate it and process its data structure. The file looks like the following, and can match either tuple patterns or an arbitrary Regex
-applied to the *short-description* (`mix dialyzer --format short`):
+Dialyxir also recognizes an Elixir format of the ignore file. If your ignore file is an `exs` file, Dialyxir will evaluate it and process its data structure. Entries for existing warnings can be generated with `mix dialyzer --format ignore_file`. Lines may be either tuples or an arbitrary Regex
+applied to the *short-description* (`mix dialyzer --format short`). The file looks like the following:
 
 ```elixir
 # .dialyzer_ignore.exs

--- a/lib/dialyxir/dialyzer.ex
+++ b/lib/dialyxir/dialyzer.ex
@@ -25,6 +25,9 @@ defmodule Dialyxir.Dialyzer do
             split[:format] == "dialyxir" ->
               :dialyxir
 
+            split[:format] == "ignore_file" ->
+              :ignore_file
+
             split[:format] == "raw" ->
               :raw
 

--- a/lib/dialyxir/formatter.ex
+++ b/lib/dialyxir/formatter.ex
@@ -25,6 +25,7 @@ defmodule Dialyxir.Formatter do
       filtered_warnings
       |> filter_legacy_warnings(filterer)
       |> Enum.map(&format_warning(&1, formatter))
+      |> Enum.uniq()
 
     show_count_skipped(warnings, formatted_warnings, filter_map)
     formatted_unnecessary_skips = format_unnecessary_skips(filter_map)
@@ -71,6 +72,10 @@ defmodule Dialyxir.Formatter do
     string = warning.format_short(arguments)
 
     "#{base_name}:#{line}:#{warning_name} #{string}"
+  end
+
+  defp format_warning({_tag, {file, _line}, {warning_name, _arguments}}, :ignore_file) do
+    ~s({"#{file}", :#{warning_name}},)
   end
 
   defp format_warning(dialyzer_warning = {_tag, {file, line}, message}, :dialyxir) do

--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -21,6 +21,7 @@ defmodule Mix.Tasks.Dialyzer do
     * `--format raw` - format the warnings in format returned before Dialyzer formatting
     * `--format dialyxir` - format the warnings in a pretty printed format
     * `--format dialyzer` - format the warnings in the original Dialyzer format
+    * `--format ignore_file` - format the warnings to be suitable for adding to Elixir Format ignore file
     * `--quiet` - suppress all informational messages
 
   Warning flags passed to this task are passed on to `:dialyzer` - e.g.

--- a/test/fixtures/ignore/ignore_test.exs
+++ b/test/fixtures/ignore/ignore_test.exs
@@ -1,4 +1,6 @@
 [
-  {"a/file.ex:17:no_return Function format_long/1 has no local return."},
+  {"lib/short_description.ex:17:no_return Function format_long/1 has no local return."},
+  {"lib/file/warning_type.ex", :no_return, 18},
+  {"lib/file/warning_type/line.ex", :no_return, 19},
   ~r/regex_file.ex.*no local return/
 ]


### PR DESCRIPTION
Hi,
when starting to use dialyxir in a legacy project, it's often useful to get output with all of the existing warnings ready to be put to the ignores file as is. Then to be able to enforce dialyxir checks on CI to prevent further increase of technical debt.
What do you think of this PR? If that's fine I'd add option description to README as well.