### PR TITLE
only run CI on master and on PRs against master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
+    branches: [ master ]
   pull_request:
-    branches:
-      - master
+    branches: [ master ]
 
 jobs:
   check_duplicate_runs:


### PR DESCRIPTION
This is slightly more constrained and will also still work if you decide to change the default branch