### PR TITLE
Fix crash when mix.lock was missing

### DIFF
--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -386,7 +386,23 @@ defmodule Mix.Tasks.Dialyzer do
     {apps, hash}
   end
 
-  def lock_file() do
-    Mix.Project.config()[:lockfile] |> File.read!()
+  defp lock_file() do
+    lockfile = Mix.Project.config()[:lockfile]
+    read_res = File.read(lockfile)
+
+    case read_res do
+      {:ok, data} ->
+        data
+
+      {:error, :enoent} ->
+        # If there is no lock file, an empty bitstring will do to indicate there is none there
+        <<>>
+
+      {:error, reason} ->
+        raise File.Error,
+          reason: reason,
+          action: "read file",
+          path: lockfile
+    end
   end
 end

--- a/test/fixtures/no_lockfile/mix.exs
+++ b/test/fixtures/no_lockfile/mix.exs
@@ -1,0 +1,10 @@
+defmodule NoLockfile.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :no_lockfile,
+      version: "1.0.0"
+    ]
+  end
+end

--- a/test/mix/tasks/dialyzer_test.exs
+++ b/test/mix/tasks/dialyzer_test.exs
@@ -42,6 +42,14 @@ defmodule Mix.Tasks.DialyzerTest do
     end)
   end
 
+  test "Does not crash when running on project without mix.lock" do
+    in_project(:no_lockfile, fn ->
+      fun = fn -> Mix.Tasks.Dialyzer.clean([], &no_delete_plt/4) end
+      capture_io(fun)
+      # does not assert anything, we just need to ensure this doesn't crash.
+    end)
+  end
+
   @tag :output_tests
   test "Informational output is suppressed with --quiet" do
     args = ["dialyzer", "--quiet"]


### PR DESCRIPTION
Closes #472

See that issue for more details on the issue. A non-existent lockfile is probably ok to be non-fatal (especially considering by default `mix` projects do not include one), so I just chose to treat it the same as an empty file. 