### PR TITLE
Add `:no-umbrella` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,3 +371,15 @@ dialyzer: [
 
 This option can also be set on the command line with `--list-unused-filters`. When used without
 `--ignore-exit-status`, this option will result in an error status code.
+
+#### `no_umbrella` flag
+
+Projects with lockfiles at a parent folder are treated as umbrella projects. In some cases however
+you may wish to have the lockfile on a parent folder without having an umbrella. By setting the
+`no_umbrella` flag to `true` your project will be treated as a non umbrella project:
+
+```elixir
+dialyzer: [
+  no_umbrella: true
+]
+```

--- a/lib/dialyxir/project.ex
+++ b/lib/dialyxir/project.ex
@@ -109,6 +109,13 @@ defmodule Dialyxir.Project do
     Mix.Project.config()[:dialyzer][:flags] || []
   end
 
+  def no_umbrella? do
+    case dialyzer_config()[:no_umbrella] do
+      true -> true
+      _other -> false
+    end
+  end
+
   defp skip?({file, warning, line}, {file, warning, line, _}), do: true
   defp skip?({file, warning}, {file, warning, _, _}), do: true
   defp skip?({file}, {file, _, _, _}), do: true

--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -295,7 +295,10 @@ defmodule Mix.Tasks.Dialyzer do
   end
 
   defp in_child? do
-    String.contains?(Mix.Project.config()[:lockfile], "..")
+    case Project.no_umbrella?() do
+      true -> false
+      false -> String.contains?(Mix.Project.config()[:lockfile], "..")
+    end
   end
 
   defp no_plt? do

--- a/test/dialyxir/project_test.exs
+++ b/test/dialyxir/project_test.exs
@@ -184,4 +184,14 @@ defmodule Dialyxir.ProjectTest do
       assert Project.list_unused_filters?(list_unused_filters: nil)
     end)
   end
+
+  test "no_umbrella? works as expected" do
+    in_project(:umbrella, fn ->
+      refute Project.no_umbrella?()
+    end)
+
+    in_project(:no_umbrella, fn ->
+      assert Project.no_umbrella?()
+    end)
+  end
 end

--- a/test/fixtures/no_umbrella/mix.exs
+++ b/test/fixtures/no_umbrella/mix.exs
@@ -1,0 +1,23 @@
+defmodule NoUmbrella.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :no_umbrella,
+      version: "0.1.0",
+      lockfile: "../mix.lock",
+      elixir: "~> 1.3",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: [],
+      dialyzer: [no_umbrella: true]
+    ]
+  end
+
+  # Configuration for the OTP application
+  #
+  # Type "mix help compile.app" for more information
+  def application do
+    [applications: [:logger, :public_key]]
+  end
+end


### PR DESCRIPTION
In some cases you may want to place the `lockfile` in a parent folder without having an umbrella. With this extra option you avoid compilation at the parent folder which will fail since in such cases there is no `mix.exs`. If this flag is not set then the behaviour remains unchanged.