### PR TITLE
Use explicit ubuntu version with matrix support.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,14 @@ jobs:
   check_duplicate_runs:
     name: Check for duplicate runs
     continue-on-error: true
-    runs-on: ubuntu20
+    runs-on: ubuntu-20.04
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
         with:
+          github_token: ${{ github.token }}
           concurrent_skipping: always
           cancel_others: true
           skip_after_successful_duplicate: true
@@ -25,7 +26,7 @@ jobs:
 
   test:
     name: Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
-    runs-on: ubuntu20
+    runs-on: ubuntu-20.04
     needs: check_duplicate_runs
     if: ${{ needs.check_duplicate_runs.outputs.should_skip != 'true' }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,16 +34,13 @@ jobs:
       fail-fast: false
       matrix:
         elixir:
-        - '1.10.4'
-        - '1.11.4'
-        - '1.12.2'
+        - '1.12.3'
+        - '1.13.4'
+        - '1.14.3'
         otp:
-        - '22.3'
         - '23.3'
-        - '24.0'
-        exclude:
-          - elixir: '1.10.4'
-            otp: '24.0'
+        - '24.3'
+        - '25.3'
 
     steps:
     - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   check_duplicate_runs:
     name: Check for duplicate runs
     continue-on-error: true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu20
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
@@ -25,7 +25,7 @@ jobs:
 
   test:
     name: Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu20
     needs: check_duplicate_runs
     if: ${{ needs.check_duplicate_runs.outputs.should_skip != 'true' }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,10 @@ jobs:
         - '24.3'
         - '25.3'
 
+        exclude:
+          - elixir: '1.12.3'
+            otp: '25.3'
+
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.12.2
-erlang 24.0.5
+elixir 1.14.3-otp-25
+erlang 25.2.2

--- a/lib/dialyxir/project.ex
+++ b/lib/dialyxir/project.ex
@@ -42,7 +42,7 @@ defmodule Dialyxir.Project do
 
   def cons_apps do
     # compile & load all deps paths
-    Mix.Tasks.Deps.Loadpaths.run([])
+    _ = Mix.Tasks.Deps.Loadpaths.run([])
     # compile & load current project paths
     Mix.Task.run("compile")
     apps = plt_apps() || plt_add_apps() ++ include_deps()


### PR DESCRIPTION
`ubuntu-latest` is a moving target, it now points to 22 which has [little support](https://github.com/erlef/setup-beam#compatibility-between-operating-system-and-erlangotp) for older OTP versions. Arguably our matrix is a little too conservative with retaining older versions and we're also updating our matrix but I think OTP 23 support is still reasonable and anyway I'd rather pin to a specific release.