### PR TITLE
Add --quiet-with-result flag

### DIFF
--- a/lib/dialyxir/dialyzer.ex
+++ b/lib/dialyxir/dialyzer.ex
@@ -1,5 +1,5 @@
 defmodule Dialyxir.Dialyzer do
-  import Dialyxir.Output, only: [color: 2, info: 1]
+  import Dialyxir.Output
   alias String.Chars
   alias Dialyxir.Formatter
   alias Dialyxir.Project
@@ -10,12 +10,15 @@ defmodule Dialyxir.Dialyzer do
       :raw,
       :format,
       :list_unused_filters,
-      :ignore_exit_status
+      :ignore_exit_status,
+      :quiet_with_result
     ]
 
     def run(args, filterer) do
       try do
         {split, args} = Keyword.split(args, @dialyxir_args)
+
+        quiet_with_result? = split[:quiet_with_result]
 
         formatter =
           cond do
@@ -59,7 +62,13 @@ defmodule Dialyxir.Dialyzer do
 
         filter_map_args = FilterMap.to_args(split)
 
-        case Formatter.format_and_filter(result, filterer, filter_map_args, formatter) do
+        case Formatter.format_and_filter(
+               result,
+               filterer,
+               filter_map_args,
+               formatter,
+               quiet_with_result?
+             ) do
           {:ok, formatted_warnings, :no_unused_filters} ->
             {:ok, {formatted_time_elapsed, formatted_warnings, ""}}
 

--- a/test/mix/tasks/dialyzer_test.exs
+++ b/test/mix/tasks/dialyzer_test.exs
@@ -57,4 +57,14 @@ defmodule Mix.Tasks.DialyzerTest do
     {result, 0} = System.cmd("mix", args, env: env)
     assert result == ""
   end
+
+  @tag :output_tests
+  test "Only final result is printed with --quiet-with-result" do
+    args = ["dialyzer", "--quiet-with-result"]
+    env = [{"MIX_ENV", "prod"}]
+    {result, 0} = System.cmd("mix", args, env: env)
+
+    assert result =~
+             ~r/Total errors: ., Skipped: ., Unnecessary Skips: .\ndone \(passed successfully\)\n/
+  end
 end


### PR DESCRIPTION
An alternative to `--quiet` that doesn't print any of the:
```
Finding suitable PLTs
Checking PLT...
[:amqp, :amqp10_client, :amqp10_common, :amqp_client, :argon2_elixir, :asn1, :bus, :castore, :certifi, :combine, :compiler, :configparser_ex, :connection, :cowboy, :cowboy_telemetry, :cowlib, :crypto, :db_connection, :decimal, :ecto, :ecto_sql, :eex, :elixir, :elixir_uuid, :ex_aws, :ex_aws_rds, :ex_aws_s3, :expo, :gettext, :gun, :hackney, :hierarch, :inets, :jason, :jsx, :kernel, :logger, :logger_json, :metrics, :mime, ...]
PLT is up to date!
No :ignore_warnings opt specified in mix.exs. Using default: .dialyzer_ignore.exs.

Starting Dialyzer
[
  check_plt: false,
  init_plt: '/Users/noah/Git/project/priv/plts/dialyzer.plt',
  files: ['/Users/noah/Git/project/_build/dev/lib/project/...',
   ...],
  warnings: [:underspecs, :unknown]
]
```

But _does_ print:
```
Total errors: 207, Skipped: 207, Unnecessary Skips: 0
done (passed successfully)
```