### PR TITLE
Elixir 1.15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,14 +37,28 @@ jobs:
         - '1.12.3'
         - '1.13.4'
         - '1.14.3'
+        - '1.15.4'
         otp:
         - '23.3'
         - '24.3'
         - '25.3'
+        - '26.0'
 
         exclude:
           - elixir: '1.12.3'
             otp: '25.3'
+
+          - elixir: '1.12.3'
+            otp: '26.0'
+
+          - elixir: '1.13.4'
+            otp: '26.0'
+
+          - elixir: '1.14.3'
+            otp: '26.0'
+
+          - elixir: '1.15.4'
+            otp: '23.3'
 
     steps:
     - name: Checkout
@@ -87,7 +101,7 @@ jobs:
         MIX_ENV: prod
 
     - name: Check source code formatting
-      if: ${{ matrix.elixir > '1.12.0' }}
+      if: ${{ matrix.elixir > '1.15.0' }}
       run: mix format --check-formatted
 
     - name: Get results in short format

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.14.3-otp-25
-erlang 25.2.2
+elixir 1.15.4-otp-26
+erlang 26.0.2

--- a/lib/dialyxir/plt.ex
+++ b/lib/dialyxir/plt.ex
@@ -63,7 +63,7 @@ defmodule Dialyxir.Plt do
   end
 
   defp app_info(app) do
-    app_file = Atom.to_charlist(app) ++ '.app'
+    app_file = Atom.to_charlist(app) ++ ~c".app"
 
     case :code.where_is_file(app_file) do
       :non_existing ->
@@ -111,7 +111,7 @@ defmodule Dialyxir.Plt do
   end
 
   defp resolve_module(module, beams) do
-    beam = Atom.to_charlist(module) ++ '.beam'
+    beam = Atom.to_charlist(module) ++ ~c".beam"
 
     case :code.where_is_file(beam) do
       path when is_list(path) ->

--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -339,28 +339,34 @@ defmodule Mix.Tasks.Dialyzer do
     end
   end
 
-  defp check_dialyzer do
-    if not Code.ensure_loaded?(:dialyzer) do
-      error("""
-      DEPENDENCY MISSING
-      ------------------------
-      If you are reading this message, then Elixir and Erlang are installed but the
-      Erlang Dialyzer is not available. Probably this is because you installed Erlang
-      with your OS package manager and the Dialyzer package is separate.
+  if Version.match?(System.version(), ">= 1.15.0") do
+    defp check_dialyzer do
+      Mix.ensure_application!(:dialyzer)
+    end
+  else
+    defp check_dialyzer do
+      if not Code.ensure_loaded?(:dialyzer) do
+        error("""
+        DEPENDENCY MISSING
+        ------------------------
+        If you are reading this message, then Elixir and Erlang are installed but the
+        Erlang Dialyzer is not available. Probably this is because you installed Erlang
+        with your OS package manager and the Dialyzer package is separate.
 
-      On Debian/Ubuntu:
+        On Debian/Ubuntu:
 
-        `apt-get install erlang-dialyzer`
+          `apt-get install erlang-dialyzer`
 
-      Fedora:
+        Fedora:
 
-         `yum install erlang-dialyzer`
+          `yum install erlang-dialyzer`
 
-      Arch and Homebrew include Dialyzer in their base erlang packages. Please report a Github
-      issue to add or correct distribution-specific information.
-      """)
+        Arch and Homebrew include Dialyzer in their base erlang packages. Please report a Github
+        issue to add or correct distribution-specific information.
+        """)
 
-      :erlang.halt(3)
+        :erlang.halt(3)
+      end
     end
   end
 

--- a/test/dialyxir/formatter_test.exs
+++ b/test/dialyxir/formatter_test.exs
@@ -17,11 +17,11 @@ defmodule Dialyxir.FormatterTest do
   describe "exs ignore" do
     test "evaluates an ignore file and ignores warnings matching the pattern" do
       warnings = [
-        {:warn_return_no_exit, {'lib/short_description.ex', 17},
+        {:warn_return_no_exit, {~c"lib/short_description.ex", 17},
          {:no_return, [:only_normal, :format_long, 1]}},
-        {:warn_return_no_exit, {'lib/file/warning_type.ex', 18},
+        {:warn_return_no_exit, {~c"lib/file/warning_type.ex", 18},
          {:no_return, [:only_normal, :format_long, 1]}},
-        {:warn_return_no_exit, {'lib/file/warning_type/line.ex', 19},
+        {:warn_return_no_exit, {~c"lib/file/warning_type/line.ex", 19},
          {:no_return, [:only_normal, :format_long, 1]}}
       ]
 
@@ -35,11 +35,11 @@ defmodule Dialyxir.FormatterTest do
 
     test "evaluates an ignore file of the form {file, short_description} and ignores warnings matching the pattern" do
       warnings = [
-        {:warn_return_no_exit, {'lib/poorly_written_code.ex', 10},
+        {:warn_return_no_exit, {~c"lib/poorly_written_code.ex", 10},
          {:no_return, [:only_normal, :do_a_thing, 1]}},
-        {:warn_return_no_exit, {'lib/poorly_written_code.ex', 20},
+        {:warn_return_no_exit, {~c"lib/poorly_written_code.ex", 20},
          {:no_return, [:only_normal, :do_something_else, 2]}},
-        {:warn_return_no_exit, {'lib/poorly_written_code.ex', 30},
+        {:warn_return_no_exit, {~c"lib/poorly_written_code.ex", 30},
          {:no_return, [:only_normal, :do_many_things, 3]}}
       ]
 
@@ -53,7 +53,7 @@ defmodule Dialyxir.FormatterTest do
 
     test "does not filter lines not matching the pattern" do
       warning =
-        {:warn_return_no_exit, {'a/different_file.ex', 17},
+        {:warn_return_no_exit, {~c"a/different_file.ex", 17},
          {:no_return, [:only_normal, :format_long, 1]}}
 
       in_project(:ignore, fn ->
@@ -66,7 +66,7 @@ defmodule Dialyxir.FormatterTest do
 
     test "can filter by regex" do
       warning =
-        {:warn_return_no_exit, {'a/regex_file.ex', 17},
+        {:warn_return_no_exit, {~c"a/regex_file.ex", 17},
          {:no_return, [:only_normal, :format_long, 1]}}
 
       in_project(:ignore, fn ->
@@ -79,7 +79,7 @@ defmodule Dialyxir.FormatterTest do
 
     test "lists unnecessary skips as warnings if ignoring exit status" do
       warning =
-        {:warn_return_no_exit, {'a/regex_file.ex', 17},
+        {:warn_return_no_exit, {~c"a/regex_file.ex", 17},
          {:no_return, [:only_normal, :format_long, 1]}}
 
       filter_args = [{:ignore_exit_status, true}]
@@ -94,7 +94,7 @@ defmodule Dialyxir.FormatterTest do
 
     test "error on unnecessary skips without ignore_exit_status" do
       warning =
-        {:warn_return_no_exit, {'a/regex_file.ex', 17},
+        {:warn_return_no_exit, {~c"a/regex_file.ex", 17},
          {:no_return, [:only_normal, :format_long, 1]}}
 
       filter_args = [{:ignore_exit_status, false}]
@@ -109,7 +109,7 @@ defmodule Dialyxir.FormatterTest do
 
     test "overwrite ':list_unused_filters_present'" do
       warning =
-        {:warn_return_no_exit, {'a/regex_file.ex', 17},
+        {:warn_return_no_exit, {~c"a/regex_file.ex", 17},
          {:no_return, [:only_normal, :format_long, 1]}}
 
       filter_args = [{:list_unused_filters, false}]
@@ -126,7 +126,7 @@ defmodule Dialyxir.FormatterTest do
   describe "simple string ignore" do
     test "evaluates an ignore file and ignores warnings matching the pattern" do
       warning =
-        {:warn_matching, {'a/file.ex', 17}, {:pattern_match, ['pattern \'ok\'', '\'error\'']}}
+        {:warn_matching, {~c"a/file.ex", 17}, {:pattern_match, [~c"pattern 'ok'", ~c"'error'"]}}
 
       in_project(:ignore_string, fn ->
         assert Formatter.format_and_filter([warning], Project, [], :dialyzer) ==
@@ -137,9 +137,9 @@ defmodule Dialyxir.FormatterTest do
 
   test "listing unused filter behaves the same for different formats" do
     warnings = [
-      {:warn_return_no_exit, {'a/regex_file.ex', 17},
+      {:warn_return_no_exit, {~c"a/regex_file.ex", 17},
        {:no_return, [:only_normal, :format_long, 1]}},
-      {:warn_return_no_exit, {'a/another-file.ex', 18}, {:unknown_type, {:M, :F, :A}}}
+      {:warn_return_no_exit, {~c"a/another-file.ex", 18}, {:unknown_type, {:M, :F, :A}}}
     ]
 
     expected_warning = "a/another-file.ex:18"

--- a/test/dialyxir/project_test.exs
+++ b/test/dialyxir/project_test.exs
@@ -5,13 +5,17 @@ defmodule Dialyxir.ProjectTest do
   import ExUnit.CaptureIO, only: [capture_io: 1, capture_io: 2]
 
   defp in_project(app, f) when is_atom(app) do
-    Mix.Project.in_project(app, "test/fixtures/#{Atom.to_string(app)}", fn _ -> f.() end)
+    in_project(app, "test/fixtures/#{Atom.to_string(app)}", f)
   end
 
   defp in_project(apps, f) when is_list(apps) do
     path = Enum.map_join(apps, "/", &Atom.to_string/1)
     app = List.last(apps)
-    Mix.Project.in_project(app, "test/fixtures/#{path}", fn _ -> f.() end)
+    in_project(app, "test/fixtures/#{path}", f)
+  end
+
+  defp in_project(app, path, f) do
+    Mix.Project.in_project(app, path, fn _ -> f.() end)
   end
 
   test "Default Project PLT File in _build dir" do

--- a/test/fixtures/alt_core_path/mix.exs
+++ b/test/fixtures/alt_core_path/mix.exs
@@ -2,6 +2,11 @@ defmodule AltCorePath.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :alt_core_path, version: "1.0.0", dialyzer: [plt_core_path: "_build"]]
+    [
+      app: :alt_core_path,
+      prune_code_paths: false,
+      version: "1.0.0",
+      dialyzer: [plt_core_path: "_build"]
+    ]
   end
 end

--- a/test/fixtures/alt_local_path/mix.exs
+++ b/test/fixtures/alt_local_path/mix.exs
@@ -2,6 +2,11 @@ defmodule AltLocalPath.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :alt_local_path, version: "1.0.0", dialyzer: [plt_local_path: "dialyzer"]]
+    [
+      app: :alt_local_path,
+      prune_code_paths: false,
+      version: "1.0.0",
+      dialyzer: [plt_local_path: "dialyzer"]
+    ]
   end
 end

--- a/test/fixtures/default_apps/mix.exs
+++ b/test/fixtures/default_apps/mix.exs
@@ -2,7 +2,7 @@ defmodule DefaultApps.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :default_apps, version: "0.1.0", deps: deps()]
+    [app: :default_apps, prune_code_paths: false, version: "0.1.0", deps: deps()]
   end
 
   def application do

--- a/test/fixtures/direct_apps/mix.exs
+++ b/test/fixtures/direct_apps/mix.exs
@@ -2,7 +2,13 @@ defmodule DirectApps.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :direct_apps, version: "0.1.0", deps: deps(), dialyzer: [plt_add_deps: :apps_direct]]
+    [
+      app: :direct_apps,
+      prune_code_paths: false,
+      version: "0.1.0",
+      deps: deps(),
+      dialyzer: [plt_add_deps: :apps_direct]
+    ]
   end
 
   def application do

--- a/test/fixtures/ignore/mix.exs
+++ b/test/fixtures/ignore/mix.exs
@@ -5,6 +5,7 @@ defmodule Ignore.Mixfile do
     [
       app: :ignore,
       version: "0.1.0",
+      prune_code_paths: false,
       dialyzer: [
         ignore_warnings: "ignore_test.exs",
         list_unused_filters: true

--- a/test/fixtures/ignore_apps/mix.exs
+++ b/test/fixtures/ignore_apps/mix.exs
@@ -5,6 +5,7 @@ defmodule IgnoreApps.Mixfile do
     [
       app: :ignore_apps,
       version: "0.1.0",
+      prune_code_paths: false,
       deps: deps(),
       dialyzer: [
         plt_ignore_apps: [:logger]

--- a/test/fixtures/ignore_strict/mix.exs
+++ b/test/fixtures/ignore_strict/mix.exs
@@ -5,6 +5,7 @@ defmodule IgnoreStrict.Mixfile do
     [
       app: :ignore_strict,
       version: "0.1.0",
+      prune_code_paths: false,
       dialyzer: [
         ignore_warnings: "ignore_strict_test.exs",
         list_unused_filters: true

--- a/test/fixtures/ignore_string/mix.exs
+++ b/test/fixtures/ignore_string/mix.exs
@@ -5,6 +5,7 @@ defmodule IgnoreString.Mixfile do
     [
       app: :ignore_string,
       version: "0.1.0",
+      prune_code_paths: false,
       dialyzer: [
         ignore_warnings: "dialyzer.ignore-warnings",
         list_unused_filters: true

--- a/test/fixtures/local_plt/mix.exs
+++ b/test/fixtures/local_plt/mix.exs
@@ -2,6 +2,11 @@ defmodule LocalPlt.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :local_plt, version: "1.0.0", dialyzer: [plt_file: "local.plt"]]
+    [
+      app: :local_plt,
+      prune_code_paths: false,
+      version: "1.0.0",
+      dialyzer: [plt_file: "local.plt"]
+    ]
   end
 end

--- a/test/fixtures/local_plt_no_warn/mix.exs
+++ b/test/fixtures/local_plt_no_warn/mix.exs
@@ -2,6 +2,11 @@ defmodule LocalPltNoWarn.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :local_plt_no_warn, version: "1.0.0", dialyzer: [plt_file: {:no_warn, "local.plt"}]]
+    [
+      app: :local_plt_no_warn,
+      prune_code_paths: false,
+      version: "1.0.0",
+      dialyzer: [plt_file: {:no_warn, "local.plt"}]
+    ]
   end
 end

--- a/test/fixtures/no_lockfile/mix.exs
+++ b/test/fixtures/no_lockfile/mix.exs
@@ -4,6 +4,7 @@ defmodule NoLockfile.Mixfile do
   def project do
     [
       app: :no_lockfile,
+      prune_code_paths: false,
       version: "1.0.0"
     ]
   end

--- a/test/fixtures/no_umbrella/mix.exs
+++ b/test/fixtures/no_umbrella/mix.exs
@@ -4,6 +4,7 @@ defmodule NoUmbrella.Mixfile do
   def project do
     [
       app: :no_umbrella,
+      prune_code_paths: false,
       version: "0.1.0",
       lockfile: "../mix.lock",
       elixir: "~> 1.3",

--- a/test/fixtures/nonexistent_deps/mix.exs
+++ b/test/fixtures/nonexistent_deps/mix.exs
@@ -2,7 +2,12 @@ defmodule NonexistentDeps.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :nonexistent_deps, version: "0.1.0", deps: deps()]
+    [
+      app: :nonexistent_deps,
+      prune_code_paths: false,
+      version: "0.1.0",
+      deps: deps()
+    ]
   end
 
   def application do

--- a/test/fixtures/plt_add_deps_deprecations/mix.exs
+++ b/test/fixtures/plt_add_deps_deprecations/mix.exs
@@ -4,6 +4,7 @@ defmodule PltAddDepsDeprecations.Mixfile do
   def project do
     [
       app: :plt_add_deps_deprecations,
+      prune_code_paths: false,
       version: "0.1.0",
       dialyzer: [
         plt_add_deps: true

--- a/test/fixtures/umbrella/apps/first_one/mix.exs
+++ b/test/fixtures/umbrella/apps/first_one/mix.exs
@@ -4,6 +4,7 @@ defmodule FirstOne.Mixfile do
   def project do
     [
       app: :first_one,
+      prune_code_paths: false,
       version: "0.1.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/test/fixtures/umbrella/apps/second_one/mix.exs
+++ b/test/fixtures/umbrella/apps/second_one/mix.exs
@@ -4,6 +4,7 @@ defmodule SecondOne.Mixfile do
   def project do
     [
       app: :second_one,
+      prune_code_paths: false,
       version: "0.1.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/test/fixtures/umbrella/mix.exs
+++ b/test/fixtures/umbrella/mix.exs
@@ -4,6 +4,7 @@ defmodule Umbrella.Mixfile do
   def project do
     [
       apps_path: "apps",
+      prune_code_paths: false,
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: []

--- a/test/fixtures/umbrella_ignore_apps/apps/first_one/mix.exs
+++ b/test/fixtures/umbrella_ignore_apps/apps/first_one/mix.exs
@@ -4,6 +4,7 @@ defmodule FirstOne.Mixfile do
   def project do
     [
       app: :first_one,
+      prune_code_paths: false,
       version: "0.1.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/test/fixtures/umbrella_ignore_apps/apps/second_one/mix.exs
+++ b/test/fixtures/umbrella_ignore_apps/apps/second_one/mix.exs
@@ -4,6 +4,7 @@ defmodule SecondOne.Mixfile do
   def project do
     [
       app: :second_one,
+      prune_code_paths: false,
       version: "0.1.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/test/fixtures/umbrella_ignore_apps/mix.exs
+++ b/test/fixtures/umbrella_ignore_apps/mix.exs
@@ -4,6 +4,7 @@ defmodule UmbrellaIgnoreApps.Mixfile do
   def project do
     [
       apps_path: "apps",
+      prune_code_paths: false,
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: [],

--- a/test/warning_test.exs
+++ b/test/warning_test.exs
@@ -4,7 +4,7 @@ defmodule Dialyxir.Test.WarningTest do
   # Don't test output in here, just that it can succeed.
 
   test "pattern match warning succeeds on valid input" do
-    arguments = ['pattern {\'ok\', Vuser@1}', '{\'error\',<<_:64,_:_*8>>}']
+    arguments = [~c"pattern {'ok', Vuser@1}", ~c"{'error',<<_:64,_:_*8>>}"]
     assert(Dialyxir.Warnings.PatternMatch.format_long(arguments))
   end
 end


### PR DESCRIPTION
Resolves #511 

This uses `Mix.ensure_application!/1` instead of `Code.ensure_loaded?/1`. This is similar to how missing erlang libraries are dealt with in other repos:

https://github.com/nccgroup/sobelow/pull/143
https://github.com/phoenixframework/tailwind/commit/68185c77c7f83c6b634cc7624b19633cb61b83d2

This PR also tests on Elixir 1.15 and OTP 26, but there are issues getting the tests to succeed. I'll see if I can get the tests to succeed.