### PR TITLE
Bump minimal required Elixir version to 1.12.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Dialyxir.Mixfile do
     [
       app: :dialyxir,
       version: @version,
-      elixir: ">= 1.6.0",
+      elixir: ">= 1.12.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       description: description(),
       package: package(),


### PR DESCRIPTION
Since PR #514, the [`Kernel.then/2` macro](https://hexdocs.pm/elixir/Kernel.html#then/2) is used, which was introduced in Elixir 1.12.0. If installed on older Elixir versions, it will fail to compile with the error below.

```
==> dialyxir
Compiling 66 files (.ex)

== Compilation error in file lib/dialyxir/project.ex ==
** (CompileError) lib/dialyxir/project.ex:365: undefined function then/2
    (elixir) expanding macro: Kernel.|>/2
    lib/dialyxir/project.ex:365: Dialyxir.Project (module)
    (elixir) expanding macro: Kernel.if/2
    lib/dialyxir/project.ex:365: Dialyxir.Project (module)
```

Bump the minimal required Elixir version to communicate older versions are no longer supported. Elixir 1.12 is also the oldest version tested in the CI.

If it wasn't the intention to drop support for older Elixir versions, please close this PR :)
