### PR TITLE
chore: remove then to be compatible with elixir 1.11

### DIFF
--- a/lib/dialyxir/project.ex
+++ b/lib/dialyxir/project.ex
@@ -458,7 +458,7 @@ defmodule Dialyxir.Project do
     end
   end
 
-  if System.version() |> Version.parse!() |> then(&(&1.major >= 1 and &1.minor >= 15)) do
+  if System.version() |> Version.parse!() |> (&(&1.major >= 1 and &1.minor >= 15)).() do
     defp app_dep_specs(app) do
       # Values returned by :optional_applications are also in :applications.
       dependencies = Application.spec(app, :applications) || []


### PR DESCRIPTION
Resolves an issue when compiling with elixir 1.11 as mentioned here: #514

```
== Compilation error in file lib/dialyxir/project.ex ==
Error: ** (CompileError) lib/dialyxir/project.ex:365: undefined function then/2
```