### PR TITLE
Fix Formatting of `:record_match`

### DIFF
--- a/lib/dialyxir/warnings.ex
+++ b/lib/dialyxir/warnings.ex
@@ -41,6 +41,7 @@ defmodule Dialyxir.Warnings do
                 Dialyxir.Warnings.PatternMatch,
                 Dialyxir.Warnings.PatternMatchCovered,
                 Dialyxir.Warnings.RecordConstruction,
+                Dialyxir.Warnings.RecordMatch,
                 Dialyxir.Warnings.RecordMatching,
                 Dialyxir.Warnings.UnknownBehaviour,
                 Dialyxir.Warnings.UnknownFunction,

--- a/lib/dialyxir/warnings/record_match.ex
+++ b/lib/dialyxir/warnings/record_match.ex
@@ -1,0 +1,17 @@
+defmodule Dialyxir.Warnings.RecordMatch do
+  @behaviour Dialyxir.Warning
+
+  @impl Dialyxir.Warning
+  @spec warning() :: :record_match
+  def warning(), do: :record_match
+
+  @impl Dialyxir.Warning
+  @spec format_short([String.t()]) :: String.t()
+  defdelegate format_short(args), to: Dialyxir.Warnings.RecordMatching
+
+  @impl Dialyxir.Warning
+  defdelegate format_long(args), to: Dialyxir.Warnings.RecordMatching
+
+  @impl Dialyxir.Warning
+  defdelegate explain(), to: Dialyxir.Warnings.RecordMatching
+end


### PR DESCRIPTION
Fixes #445

Example Error before:

```
Please file a bug in https://github.com/jeremyjh/dialyxir/issues with this message.

Unknown warning:
:record_match


Legacy warning:
src/jwe/jose_jwe_alg_ecdh_ss.erl:269:1: Matching of pattern {'jose_jwe_alg_ecdh_ss', SPK = {'jose_jwk', _, _, _}, _, _, _, _, _, _} tagged with a record name violates the declared type of #jose_jwe_alg_ecdh_ss{spk::'undefined' | {_,map()},apu::'undefined' | binary(),apv::'undefined' | binary(),wrap::'aes_gcm_kw' | 'aes_kw' | 'c20p_kw' | 'undefined' | 'xc20p_kw',bits::'undefined' | 128 | 192 | 256,iv::'undefined' | binary(),tag::'undefined' | binary()}
```

Example Error after:

```
src/jwe/jose_jwe_alg_ecdh_ss.erl:269:1:record_match
The pattern {'jose_jwe_alg_ecdh_ss', SPK = {'jose_jwk', _, _, _}, _, _, _, _, _, _} violates the declared type for ##jose_jwe_alg_ecdh_ss{spk::'undefined' | {_,map()},apu::'undefined' | binary(),apv::'undefined' | binary(),wrap::'aes_gcm_kw' | 'aes_kw' | 'c20p_kw' | 'undefined' | 'xc20p_kw',bits::'undefined' | 128 | 192 | 256,iv::'undefined' | binary(),tag::'undefined' | binary()}{}.
```