### PR TITLE
Support multiple formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,21 +36,21 @@ mix dialyzer
 
 ### Command line options
 
-  * `--no-compile`                 - do not compile even if needed.
-  * `--no-check`                   - do not perform (quick) check to see if PLT needs to be updated.
-  * `--ignore-exit-status`         - display warnings but do not halt the VM or return an exit status code.
-  * `--list-unused-filters` - list unused ignore filters useful for CI. do
-      not use with `mix do`.
-  * `--plt` - only build the required PLT(s) and exit
-  *  `--format short`              - format the warnings in a compact format, suitable for ignore file using Elixir term format.
-  *  `--format raw`                - format the warnings in format returned before Dialyzer formatting.
-  *  `--format dialyxir`           - format the warnings in a pretty printed format. (default)
-  *  `--format dialyzer`           - format the warnings in the original Dialyzer format, suitable for ignore file using simple string matches.
-  *  `--format github`             - format the warnings in the Github Actions message format.
-  *  `--format ignore_file`        - format the warnings in {file, warning} format for Elixir Format ignore file.
-  *  `--format ignore_file_strict` - format the warnings in {file, short_description} format for Elixir Format ignore file.
-  *  `--quiet`                     - suppress all informational messages.
-  *  `--quiet-with-result`         - suppress all informational messages except for the final result message
+  * `--no-compile`                  - do not compile even if needed.
+  * `--no-check`                    - do not perform (quick) check to see if PLT needs to be updated.
+  * `--ignore-exit-status`          - display warnings but do not halt the VM or return an exit status code.
+  * `--list-unused-filters`         - list unused ignore filters useful for CI. do not use with `mix do`.
+  * `--plt` - only build the requir ed PLT(s) and exit.
+  * `--format <name>`               - Specify the format for the warnings, can be specified multiple times to print warnings multiple times in different output formats. Defaults to `dialyxir`.
+    * `--format short`              - format the warnings in a compact format, suitable for ignore file using Elixir term format.
+    * `--format raw`                - format the warnings in format returned before Dialyzer formatting.
+    * `--format dialyxir`           - format the warnings in a pretty printed format. (default)
+    * `--format dialyzer`           - format the warnings in the original Dialyzer format, suitable for ignore file using simple string matches.
+    * `--format github`             - format the warnings in the Github Actions message format.
+    * `--format ignore_file`        - format the warnings in {file, warning} format for Elixir Format ignore file.
+    * `--format ignore_file_strict` - format the warnings in {file, short_description} format for Elixir Format ignore file.
+  * `--quiet`                       - suppress all informational messages.
+  * `--quiet-with-result`           - suppress all informational messages except for the final result message.
 
 Warning flags passed to this task are passed on to `:dialyzer` - e.g.
 

--- a/docs/github_actions.md
+++ b/docs/github_actions.md
@@ -42,7 +42,10 @@ steps:
         priv/plts
 
   - name: Run dialyzer
-    run: mix dialyzer --format github
+    # Two formats are included for ease of debugging and it is lightly recommended to use both, see https://github.com/jeremyjh/dialyxir/issues/530 for reasoning
+    # --format github is helpful to print the warnings in a way that GitHub understands and can place on the /files page of a PR
+    # --format dialyxir allows the raw GitHub actions logs to be useful because they have the full warning printed
+    run: mix dialyzer --format github --format dialyxir
 
 # ...
 ```

--- a/lib/dialyxir/dialyzer.ex
+++ b/lib/dialyxir/dialyzer.ex
@@ -83,6 +83,7 @@ defmodule Dialyxir.Dialyzer do
       Known formatters are dialyzer, dialyxir, github, ignore_file, ignore_file_string, raw, and short. \
       Falling back to dialyxir.
       """)
+
       @default_formatter
     end
   end

--- a/lib/dialyxir/dialyzer.ex
+++ b/lib/dialyxir/dialyzer.ex
@@ -1,6 +1,5 @@
 defmodule Dialyxir.Dialyzer do
   import Dialyxir.Output
-  require Logger
   alias String.Chars
   alias Dialyxir.Formatter
   alias Dialyxir.Project
@@ -79,7 +78,11 @@ defmodule Dialyxir.Dialyzer do
     defp parse_formatter("short"), do: Dialyxir.Formatter.Short
 
     defp parse_formatter(unknown) do
-      Logger.warning("Unrecognized formatter #{unknown} received. Falling back to default.")
+      warning("""
+      Unrecognized formatter #{unknown} received. \
+      Known formatters are dialyzer, dialyxir, github, ignore_file, ignore_file_string, raw, and short. \
+      Falling back to dialyxir.
+      """)
       @default_formatter
     end
   end

--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -154,7 +154,7 @@ defmodule Mix.Tasks.Dialyzer do
                      quiet: :boolean,
                      quiet_with_result: :boolean,
                      raw: :boolean,
-                     format: :string
+                     format: [:string, :keep]
                    )
 
   def run(args) do
@@ -265,7 +265,7 @@ defmodule Mix.Tasks.Dialyzer do
       {:init_plt, String.to_charlist(Project.plt_file())},
       {:files, Project.dialyzer_files()},
       {:warnings, dialyzer_warnings(dargs)},
-      {:format, opts[:format]},
+      {:format, Keyword.get_values(opts, :format)},
       {:raw, opts[:raw]},
       {:list_unused_filters, opts[:list_unused_filters]},
       {:ignore_exit_status, opts[:ignore_exit_status]},

--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -17,13 +17,14 @@ defmodule Mix.Tasks.Dialyzer do
     * `--list-unused-filters` - list unused ignore filters useful for CI. do
       not use with `mix do`.
     * `--plt` - only build the required PLT(s) and exit
-    * `--format short`       - format the warnings in a compact format
-    * `--format raw`         - format the warnings in format returned before Dialyzer formatting
-    * `--format dialyxir`    - format the warnings in a pretty printed format
-    * `--format dialyzer`    - format the warnings in the original Dialyzer format
-    * `--format github`      - format the warnings in the Github Actions message format
-    * `--format ignore_file` - format the warnings in {file, warning} format for Elixir Format ignore file
-    * `--format ignore_file_strict` - format the warnings in {file, short_description} format for Elixir Format ignore file.
+    * `--format <name>`        - Specify the format for the warnings, can be specified multiple times to print warnings multiple times in different output formats. Defaults to `dialyxir`.
+      * `--format short`       - format the warnings in a compact format, suitable for ignore file using Elixir term format.
+      * `--format raw`         - format the warnings in format returned before Dialyzer formatting
+      * `--format dialyxir`    - format the warnings in a pretty printed format (default)
+      * `--format dialyzer`    - format the warnings in the original Dialyzer format
+      * `--format github`      - format the warnings in the Github Actions message format
+      * `--format ignore_file` - format the warnings in {file, warning} format for Elixir Format ignore file
+      * `--format ignore_file_strict` - format the warnings in {file, short_description} format for Elixir Format ignore file.
     * `--quiet` - suppress all informational messages
     * `--quiet-with-result` - suppress all informational messages except for the final result message
 

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule Dialyxir.Mixfile do
       deps: deps(),
       aliases: [test: "test --no-start"],
       dialyzer: [
-        plt_apps: [:dialyzer, :elixir, :kernel, :mix, :stdlib, :erlex],
+        plt_apps: [:dialyzer, :elixir, :kernel, :mix, :stdlib, :erlex, :logger],
         ignore_warnings: ".dialyzer_ignore.exs",
         flags: [:unmatched_returns, :error_handling, :underspecs]
       ],
@@ -33,7 +33,10 @@ defmodule Dialyxir.Mixfile do
   end
 
   def application do
-    [mod: {Dialyxir, []}, extra_applications: [:dialyzer, :crypto, :mix, :erts, :syntax_tools]]
+    [
+      mod: {Dialyxir, []},
+      extra_applications: [:dialyzer, :crypto, :mix, :erts, :syntax_tools, :logger]
+    ]
   end
 
   defp description do

--- a/test/mix/tasks/dialyzer_test.exs
+++ b/test/mix/tasks/dialyzer_test.exs
@@ -73,6 +73,8 @@ defmodule Mix.Tasks.DialyzerTest do
     args = ["dialyzer", "--format", "foo"]
     env = [{"MIX_ENV", "prod"}]
     {result, 0} = System.cmd("mix", args, env: env)
-    assert result =~ "Unrecognized formatter foo received. Known formatters are dialyzer, dialyxir, github, ignore_file, ignore_file_string, raw, and short. Falling back to dialyxir."
+
+    assert result =~
+             "Unrecognized formatter foo received. Known formatters are dialyzer, dialyxir, github, ignore_file, ignore_file_string, raw, and short. Falling back to dialyxir."
   end
 end

--- a/test/mix/tasks/dialyzer_test.exs
+++ b/test/mix/tasks/dialyzer_test.exs
@@ -67,4 +67,12 @@ defmodule Mix.Tasks.DialyzerTest do
     assert result =~
              ~r/Total errors: ., Skipped: ., Unnecessary Skips: .\ndone \(passed successfully\)\n/
   end
+
+  @tag :output_tests
+  test "Warning is printed when unknown format is requested" do
+    args = ["dialyzer", "--format", "foo"]
+    env = [{"MIX_ENV", "prod"}]
+    {result, 0} = System.cmd("mix", args, env: env)
+    assert result =~ "Unrecognized formatter foo received. Known formatters are dialyzer, dialyxir, github, ignore_file, ignore_file_string, raw, and short. Falling back to dialyxir."
+  end
 end


### PR DESCRIPTION
Fixes #530

One scenario where multiple formatters is helpful is on CI where you want to use the GitHub formatter along with a more verbose formatter to see more about the specific failures (especially when viewing the CI logs directly).

I add `:logger` to give the user a warning message if they provide an invalid name for a formatter but I can remove the warning if there's a specific reason to not depend on logger.

Example run:
```
> mix dialyzer --format github --format dialyxir
Finding suitable PLTs
Checking PLT...
[:compiler, :crypto, :dialyxir, :dialyzer, :elixir, :erlex, :erts, :kernel, :logger, :mix, :stdlib, :syntax_tools, :weather]
PLT is up to date!
No :ignore_warnings opt specified in mix.exs and default does not exist.

Starting Dialyzer
[
  check_plt: false,
  init_plt: ~c"/Users/jasonaxelson/dev/tmp/weather/_build/dev/dialyxir_erlang-26.2.5_elixir-1.17.2_deps-dev.plt",
  files: [~c"/Users/jasonaxelson/dev/tmp/weather/_build/dev/lib/weather/ebin/Elixir.BusinessLogic.beam",
   ~c"/Users/jasonaxelson/dev/tmp/weather/_build/dev/lib/weather/ebin/Elixir.Weather.beam",
   ~c"/Users/jasonaxelson/dev/tmp/weather/_build/dev/lib/weather/ebin/Elixir.WeatherAPI.beam",
   ~c"/Users/jasonaxelson/dev/tmp/weather/_build/dev/lib/weather/ebin/Elixir.WeatherImpl.beam"],
  warnings: [:unknown]
]
Total errors: 2, Skipped: -2, Unnecessary Skips: 0
done in 0m3.44s
::warning file=lib/weather_impl.ex,line=5,title=callback_type_mismatch::Type mismatch for @callback get_weather.
lib/weather_impl.ex:5:callback_type_mismatch
Type mismatch for @callback get_weather/1 in WeatherAPI behaviour.

Expected type:
{:error, binary()} | {:ok, map()}

Actual type:
:ok

________________________________________________________________________________
::warning file=lib/weather_impl.ex,line=11,title=callback_type_mismatch::Type mismatch for @callback fetch_weather.
lib/weather_impl.ex:11:callback_type_mismatch
Type mismatch for @callback fetch_weather/1 in WeatherAPI behaviour.

Expected type:
{:error, binary()} | {:ok, map()}

Actual type:
:ok

________________________________________________________________________________
done (warnings were emitted)
Halting VM with exit status 2
```

Updated docs in README:
![Screenshot 2024-09-20 06-37-43@2x](https://github.com/user-attachments/assets/3044b6d6-b7a3-4f02-8925-0df43cf496a9)
