### PR TITLE
Fix matching of invalid_contract args.

### DIFF
--- a/lib/dialyxir/warnings/invalid_contract.ex
+++ b/lib/dialyxir/warnings/invalid_contract.ex
@@ -31,7 +31,11 @@ defmodule Dialyxir.Warnings.InvalidContract do
 
   @impl Dialyxir.Warning
   @spec format_long([String.t()]) :: String.t()
-  def format_long([module, function, arity, _args, signature | _]) do
+  def format_long([module, function, arity, signature]) do
+    format_long([module, function, arity, nil, signature])
+  end
+
+  def format_long([module, function, arity, _args, signature]) do
     pretty_module = Erlex.pretty_print(module)
     pretty_signature = Erlex.pretty_print_contract(signature)
 

--- a/lib/dialyxir/warnings/invalid_contract.ex
+++ b/lib/dialyxir/warnings/invalid_contract.ex
@@ -31,7 +31,7 @@ defmodule Dialyxir.Warnings.InvalidContract do
 
   @impl Dialyxir.Warning
   @spec format_long([String.t()]) :: String.t()
-  def format_long([module, function, arity, signature]) do
+  def format_long([module, function, arity, _args, signature | _]) do
     pretty_module = Erlex.pretty_print(module)
     pretty_signature = Erlex.pretty_print_contract(signature)
 

--- a/lib/dialyxir/warnings/invalid_contract.ex
+++ b/lib/dialyxir/warnings/invalid_contract.ex
@@ -35,7 +35,7 @@ defmodule Dialyxir.Warnings.InvalidContract do
     format_long([module, function, arity, nil, signature])
   end
 
-  def format_long([module, function, arity, _args, signature]) do
+  def format_long([module, function, arity, _args, signature | _]) do
     pretty_module = Erlex.pretty_print(module)
     pretty_signature = Erlex.pretty_print_contract(signature)
 


### PR DESCRIPTION
InvalidContract.format_long was expecting a different number of args from from what we actually get in OTP 26 & later. It looks like function args and a full function declaration are now also included, but aren't needed for this warning.

fixes #533 
fixes #539
fixes #536
fixes #525
fixes #501
fixes #523 
