### PR TITLE
Add a check whether default_ignore file is empty during execution and ignores it if is

### DIFF
--- a/lib/dialyxir/filter_map.ex
+++ b/lib/dialyxir/filter_map.ex
@@ -16,14 +16,21 @@ defmodule Dialyxir.FilterMap do
       unused_filters_as_errors?: list_unused_filters? && !ignore_exit_status?
     }
 
-    {ignore, _} =
-      ignore_file
-      |> File.read!()
-      |> Code.eval_string()
+    cond do
+      File.exists?(ignore_file) &&
+          match?(%{size: size} when size > 0, File.stat!(ignore_file)) ->
+        {ignore, _} =
+          ignore_file
+          |> File.read!()
+          |> Code.eval_string()
 
-    Enum.reduce(ignore, filter_map, fn skip, filter_map ->
-      put_in(filter_map.counters[skip], 0)
-    end)
+        Enum.reduce(ignore, filter_map, fn skip, filter_map ->
+          put_in(filter_map.counters[skip], 0)
+        end)
+
+      true ->
+        filter_map
+    end
   end
 
   @doc """

--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -187,6 +187,12 @@ defmodule Mix.Tasks.Dialyzer do
           No :ignore_warnings opt specified in mix.exs. Using default: #{default}.
           """)
 
+        ignore_warnings && File.exists?(ignore_warnings) &&
+            match?(%{size: size} when size == 0, File.stat!(default)) ->
+          info("""
+          :ignore_warnings opt specified in mix.exs: #{ignore_warnings}, but file is empty.
+          """)
+
         ignore_warnings && File.exists?(ignore_warnings) ->
           info("""
           ignore_warnings: #{ignore_warnings}


### PR DESCRIPTION
fixes #405 #542

Right now if the default ignore file `.dialyzer_ignore.exs` is empty the task will bug out as per issue https://github.com/jeremyjh/dialyxir/issues/542. This PR adds a check for file size, in case it is 0 it proceeds as if the file didn't exist and prints out an info message explaining that the file is empty.

`:ignore_warnings opt specified in mix.exs: .dialyzer_ignore.exs, but file is empty.`

Unfortunately, without my changes, the test suite is failing so I wasn't sure about adding a test for this, also my lack of in depth testing experience with Elixir.