### PR TITLE
Bugfix: Revert format option ignore_file_string to ignore_file_strict

### DIFF
--- a/lib/dialyxir/dialyzer.ex
+++ b/lib/dialyxir/dialyzer.ex
@@ -73,14 +73,14 @@ defmodule Dialyxir.Dialyzer do
     defp parse_formatter("dialyxir"), do: Dialyxir.Formatter.Dialyxir
     defp parse_formatter("github"), do: Dialyxir.Formatter.Github
     defp parse_formatter("ignore_file"), do: Dialyxir.Formatter.IgnoreFile
-    defp parse_formatter("ignore_file_string"), do: Dialyxir.Formatter.IgnoreFileStrict
+    defp parse_formatter("ignore_file_strict"), do: Dialyxir.Formatter.IgnoreFileStrict
     defp parse_formatter("raw"), do: Dialyxir.Formatter.Raw
     defp parse_formatter("short"), do: Dialyxir.Formatter.Short
 
     defp parse_formatter(unknown) do
       warning("""
       Unrecognized formatter #{unknown} received. \
-      Known formatters are dialyzer, dialyxir, github, ignore_file, ignore_file_string, raw, and short. \
+      Known formatters are dialyzer, dialyxir, github, ignore_file, ignore_file_strict, raw, and short. \
       Falling back to dialyxir.
       """)
 

--- a/test/mix/tasks/dialyzer_test.exs
+++ b/test/mix/tasks/dialyzer_test.exs
@@ -75,6 +75,6 @@ defmodule Mix.Tasks.DialyzerTest do
     {result, 0} = System.cmd("mix", args, env: env)
 
     assert result =~
-             "Unrecognized formatter foo received. Known formatters are dialyzer, dialyxir, github, ignore_file, ignore_file_string, raw, and short. Falling back to dialyxir."
+             "Unrecognized formatter foo received. Known formatters are dialyzer, dialyxir, github, ignore_file, ignore_file_strict, raw, and short. Falling back to dialyxir."
   end
 end


### PR DESCRIPTION
this PR solves unintentional change of ignore_file_strict option. Issue [546](https://github.com/jeremyjh/dialyxir/issues/546)