### PR TITLE
Fix invalid_contract to show success typing, not just repeating the spec

### DIFF
--- a/lib/dialyxir/warnings/invalid_contract.ex
+++ b/lib/dialyxir/warnings/invalid_contract.ex
@@ -35,9 +35,10 @@ defmodule Dialyxir.Warnings.InvalidContract do
     format_long([module, function, arity, nil, signature])
   end
 
-  def format_long([module, function, arity, _args, signature | _]) do
+  def format_long([module, function, arity, _args, spec, success_typing]) do
     pretty_module = Erlex.pretty_print(module)
-    pretty_signature = Erlex.pretty_print_contract(signature)
+    pretty_success_typing = Erlex.pretty_print_contract(success_typing)
+    pretty_spec = Erlex.pretty_print_contract(spec)
 
     """
     The @spec for the function does not match the success typing of the function.
@@ -46,7 +47,10 @@ defmodule Dialyxir.Warnings.InvalidContract do
     #{pretty_module}.#{function}/#{arity}
 
     Success typing:
-    @spec #{function}#{pretty_signature}
+    #{pretty_success_typing}
+
+    But the spec is:
+    #{pretty_spec}
     """
   end
 


### PR DESCRIPTION
For this error, the current output is simply the spec, which does not help by itself since the underlying error is that the success typing and the spec do not match. This modifies the warning message so that it shows both the success typing and the spec so that they can be compared and acted upon.

Fixes issue 551 reported here: https://github.com/jeremyjh/dialyxir/issues/551