### PR TITLE
Adds note about `:unknown` flag to `Default Flags` section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,13 @@ Dialyxir supports formatting the errors in several different ways:
 
 ### Flags
 
-Dialyzer supports a number of warning flags used to enable or disable certain kinds of analysis features. Until version 0.4, `dialyxir` used by default the additional warning flags shown in the example below. However some of these create warnings that are often more confusing than helpful, particularly to new users of Dialyzer. As of 0.4, there are no longer any flags used by default. To get the old behavior, specify them in your Mix project file. For compatibility reasons you can use either the `-Wwarning` convention of the dialyzer CLI, or (preferred) the `WarnOpts` atoms supported by the [API](http://erlang.org/doc/man/dialyzer.html#gui-1).  e.g.
+Dialyzer supports a number of warning flags used to enable or disable certain kinds of analysis features.
+
+Until version 0.4, `dialyxir` used by default the additional warning flags shown in the example below. However some of these create warnings that are often more confusing than helpful, particularly to new users of Dialyzer.
+
+As of 0.4, there are no longer any flags used by default except for `:unknown` (See [Dialyxir Defaults](#dialyxir-defaults)).
+
+To get the old behavior, specify them in your Mix project file. For compatibility reasons you can use either the `-Wwarning` convention of the dialyzer CLI, or (preferred) the `WarnOpts` atoms supported by the [API](http://erlang.org/doc/man/dialyzer.html#gui-1). E.g.
 
 ```elixir
 def project do


### PR DESCRIPTION
Hey there! 🖖 

I noticed a small issue when reading the [Flags section](https://github.com/jeremyjh/dialyxir?tab=readme-ov-file#flags) from the README:
> ### Flags
>
> _(..)_ As of 0.4, there are no longer any flags used by default. 

But the section below (and also Dialyxir's behavior) contradicts it:
>#### Dialyxir defaults
>
> By default `dialyxir` has always included the `:unknown` warning option so that warnings about unknown functions are returned. _(..)_

So I made a small wording update to clarify that 0.4 removed all flags except for `:unknown`, which is still included by underlying dialyxir's defaults. 
