### PR TITLE
Docs: Fix dead hex doc links by including CI config docs in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,14 @@ defmodule Dialyxir.Mixfile do
         main: "readme",
         source_url: @source_url,
         source_ref: @version,
-        extras: ["CHANGELOG.md", "README.md"]
+        groups_for_extras: ["CI Configs": ~r{docs/.?}],
+        extras: [
+          "CHANGELOG.md",
+          "README.md",
+          "docs/circleci.md",
+          "docs/github_actions.md",
+          "docs/gitlab_ci.md"
+        ]
       ]
     ]
   end


### PR DESCRIPTION
This PR 

* adds the example CI docs to the `docs` block of `mix.exs`.
*  puts them in their own grouping; because they would seem odd at the same level as the other docs

Without this, the docs produced by `ex_doc` have dead links (see: https://hexdocs.pm/dialyxir/readme.html#example-ci-configs).

### Before

```sh
➜  dialyxir git:(master) mix docs
Generating docs...
warning: documentation references file "./docs/circleci.md" but it does not exist
  README.md: (file)

warning: documentation references file "./docs/github_actions.md" but it does not exist
  README.md: (file)

warning: documentation references file "./docs/gitlab_ci.md" but it does not exist
  README.md: (file)

View "html" docs at "doc/index.html"
warning: documentation references file "./docs/circleci.md" but it does not exist
  README.md: (file)

warning: documentation references file "./docs/github_actions.md" but it does not exist
  README.md: (file)

warning: documentation references file "./docs/gitlab_ci.md" but it does not exist
  README.md: (file)
```

### After

```sh
➜  dialyxir git:(master) mix docs
Generating docs...
View "html" docs at "doc/index.html"
View "epub" docs at "doc/Dialyxir.epub"
```

Closes https://github.com/jeremyjh/dialyxir/issues/565