### PR TITLE
Fix CallWithoutOpaque function clause error on OTP-28

### DIFF
--- a/lib/dialyxir/warnings/call_without_opaque.ex
+++ b/lib/dialyxir/warnings/call_without_opaque.ex
@@ -51,6 +51,21 @@ defmodule Dialyxir.Warnings.CallWithoutOpaque do
     """
   end
 
+  # OTP 28+ format (5 arguments)
+  def format_long([module, function, args, expected_triples, _additional_type_info]) do
+    expected = form_expected_without_opaque(expected_triples)
+    pretty_module = Erlex.pretty_print(module)
+    pretty_args = Erlex.pretty_print_args(args)
+
+    """
+    Function call without opaqueness type mismatch.
+
+    Call does not have expected #{expected}.
+
+    #{pretty_module}.#{function}#{pretty_args}
+    """
+  end
+
   # We know which positions N are to blame;
   # the list of triples will never be empty.
   defp form_expected_without_opaque([{position, type, type_string}]) do

--- a/lib/dialyxir/warnings/call_without_opaque.ex
+++ b/lib/dialyxir/warnings/call_without_opaque.ex
@@ -53,17 +53,7 @@ defmodule Dialyxir.Warnings.CallWithoutOpaque do
 
   # OTP 28+ format (5 arguments)
   def format_long([module, function, args, expected_triples, _additional_type_info]) do
-    expected = form_expected_without_opaque(expected_triples)
-    pretty_module = Erlex.pretty_print(module)
-    pretty_args = Erlex.pretty_print_args(args)
-
-    """
-    Function call without opaqueness type mismatch.
-
-    Call does not have expected #{expected}.
-
-    #{pretty_module}.#{function}#{pretty_args}
-    """
+    format_long([module, function, args, expected_triples])
   end
 
   # We know which positions N are to blame;


### PR DESCRIPTION
Fixes #561 by adding support for the new 5-argument format used by OTP-28 while maintaining backward compatibility with the legacy 4-argument format.

The OTP-28 format passes additional type information as a 5th argument which we ignore for formatting purposes, using the same expected_triples data structure as before.