### PR TITLE
feat: Add OTP 27 incremental Dialyzer mode support

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.15.7-otp-26
-erlang 26.1.2
+elixir 1.19.1-otp-27
+erlang 27.3.4

--- a/lib/dialyxir/dialyzer.ex
+++ b/lib/dialyxir/dialyzer.ex
@@ -11,7 +11,8 @@ defmodule Dialyxir.Dialyzer do
       :format,
       :list_unused_filters,
       :ignore_exit_status,
-      :quiet_with_result
+      :quiet_with_result,
+      :project_files
     ]
 
     @default_formatter Dialyxir.Formatter.Dialyxir
@@ -42,6 +43,8 @@ defmodule Dialyxir.Dialyzer do
         |> info
 
         {duration_us, result} = :timer.tc(&:dialyzer.run/1, [args])
+
+        result = Dialyxir.Dialyzer.filter_to_project_files(result, split[:project_files])
 
         formatted_time_elapsed = Formatter.formatted_time(duration_us)
 
@@ -86,6 +89,16 @@ defmodule Dialyxir.Dialyzer do
 
       @default_formatter
     end
+  end
+
+  def filter_to_project_files(result, nil), do: result
+
+  def filter_to_project_files(result, project_files) do
+    project_file_set = MapSet.new(project_files)
+
+    Enum.filter(result, fn {_tag, {file, _line}, _warning} ->
+      MapSet.member?(project_file_set, file)
+    end)
   end
 
   @success_return_code 0

--- a/lib/dialyxir/project.ex
+++ b/lib/dialyxir/project.ex
@@ -9,19 +9,21 @@ defmodule Dialyxir.Project do
   # Maximum depth in the dependency tree to traverse before giving up.
   @max_dep_traversal_depth 100
 
-  def plts_list(deps, include_project \\ true, exclude_core \\ false) do
-    elixir_apps = [:elixir]
-    erlang_apps = [:erts, :kernel, :stdlib, :crypto]
+  @elixir_apps [:elixir]
+  @erlang_apps [:erts, :kernel, :stdlib, :crypto]
 
+  def core_apps, do: @erlang_apps ++ @elixir_apps
+
+  def plts_list(deps, include_project \\ true, exclude_core \\ false) do
     core_plts =
       if exclude_core do
         []
       else
-        [{elixir_plt(), elixir_apps}, {erlang_plt(), erlang_apps}]
+        [{elixir_plt(), @elixir_apps}, {erlang_plt(), @erlang_apps}]
       end
 
     if include_project do
-      [{plt_file(), deps ++ elixir_apps ++ erlang_apps} | core_plts]
+      [{plt_file(), deps ++ @elixir_apps ++ @erlang_apps} | core_plts]
     else
       core_plts
     end
@@ -532,6 +534,18 @@ defmodule Dialyxir.Project do
     else
       f.(acc)
     end
+  end
+
+  def incremental_mode? do
+    case dialyzer_config()[:incremental] do
+      true -> true
+      false -> false
+      _ -> otp_release_major() >= 27
+    end
+  end
+
+  defp otp_release_major do
+    :erlang.system_info(:otp_release) |> List.to_string() |> String.to_integer()
   end
 
   defp dialyzer_config(), do: Mix.Project.config()[:dialyzer]

--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -27,6 +27,8 @@ defmodule Mix.Tasks.Dialyzer do
       * `--format ignore_file_strict` - format the warnings in {file, short_description} format for Elixir Format ignore file.
     * `--quiet` - suppress all informational messages
     * `--quiet-with-result` - suppress all informational messages except for the final result message
+    * `--incremental` - use Dialyzer's incremental mode (requires OTP 27+, enabled by default on OTP 27+)
+    * `--no-incremental` - disable incremental mode even on OTP 27+
 
   Warning flags passed to this task are passed on to `:dialyzer` - e.g.
 
@@ -148,6 +150,7 @@ defmodule Mix.Tasks.Dialyzer do
   @command_options Keyword.merge(@old_options,
                      force_check: :boolean,
                      ignore_exit_status: :boolean,
+                     incremental: :boolean,
                      list_unused_filters: :boolean,
                      no_check: :boolean,
                      no_compile: :boolean,
@@ -166,17 +169,21 @@ defmodule Mix.Tasks.Dialyzer do
     check_dialyzer()
     compatibility_notice()
 
+    incremental? = incremental_mode?(opts)
+
     if Mix.Project.get() do
       Project.check_config()
 
       unless opts[:no_compile], do: Mix.Task.run("compile")
 
-      _ =
-        unless no_check?(opts) do
-          info("Finding suitable PLTs")
-          force_check? = Keyword.get(opts, :force_check, false)
-          check_plt(force_check?)
-        end
+      unless incremental? do
+        _ =
+          unless no_check?(opts) do
+            info("Finding suitable PLTs")
+            force_check? = Keyword.get(opts, :force_check, false)
+            check_plt(force_check?)
+          end
+      end
 
       default = Dialyxir.Project.default_ignore_warnings()
       ignore_warnings = Dialyxir.Project.dialyzer_ignore_warnings()
@@ -210,7 +217,7 @@ defmodule Mix.Tasks.Dialyzer do
       end
 
       warn_old_options(opts)
-      unless opts[:plt], do: run_dialyzer(opts, dargs)
+      unless opts[:plt], do: run_dialyzer(opts, dargs, incremental?)
     else
       info("No mix project found - checking core PLTs...")
       Project.plts_list([], false) |> Plt.check()
@@ -266,18 +273,38 @@ defmodule Mix.Tasks.Dialyzer do
     end
   end
 
-  defp run_dialyzer(opts, dargs) do
-    args = [
-      {:check_plt, opts[:force_check] || false},
-      {:init_plt, String.to_charlist(Project.plt_file())},
-      {:files, Project.dialyzer_files()},
-      {:warnings, dialyzer_warnings(dargs)},
-      {:format, Keyword.get_values(opts, :format)},
-      {:raw, opts[:raw]},
-      {:list_unused_filters, opts[:list_unused_filters]},
-      {:ignore_exit_status, opts[:ignore_exit_status]},
-      {:quiet_with_result, opts[:quiet_with_result]}
-    ]
+  defp run_dialyzer(opts, dargs, incremental?) do
+    base_args =
+      if incremental? do
+        incremental_plt = String.to_charlist(Project.plt_file() <> ".incremental")
+        project_files = Project.dialyzer_files()
+
+        [
+          {:analysis_type, :incremental},
+          {:init_plt, incremental_plt},
+          {:output_plt, incremental_plt},
+          {:files, project_files ++ dep_beam_files()},
+          {:warnings, dialyzer_warnings(dargs)},
+          {:project_files, project_files}
+        ]
+      else
+        [
+          {:check_plt, opts[:force_check] || false},
+          {:init_plt, String.to_charlist(Project.plt_file())},
+          {:files, Project.dialyzer_files()},
+          {:warnings, dialyzer_warnings(dargs)}
+        ]
+      end
+
+    args =
+      base_args ++
+        [
+          {:format, Keyword.get_values(opts, :format)},
+          {:raw, opts[:raw]},
+          {:list_unused_filters, opts[:list_unused_filters]},
+          {:ignore_exit_status, opts[:ignore_exit_status]},
+          {:quiet_with_result, opts[:quiet_with_result]}
+        ]
 
     {status, exit_status, [time | result]} = Dialyzer.dialyze(args)
     info(time)
@@ -375,6 +402,27 @@ defmodule Mix.Tasks.Dialyzer do
 
         :erlang.halt(3)
       end
+    end
+  end
+
+  defp dep_beam_files do
+    all_apps = Enum.uniq(Project.core_apps() ++ Project.cons_apps())
+
+    Enum.flat_map(all_apps, fn app ->
+      ebin_dir = Application.app_dir(app, "ebin")
+
+      if File.dir?(ebin_dir) do
+        Path.join(ebin_dir, "*.beam") |> Path.wildcard() |> Enum.map(&to_charlist/1)
+      else
+        []
+      end
+    end)
+  end
+
+  defp incremental_mode?(opts) do
+    case Keyword.fetch(opts, :incremental) do
+      {:ok, value} -> value
+      :error -> Project.incremental_mode?()
     end
   end
 

--- a/test/dialyxir/dialyzer_test.exs
+++ b/test/dialyxir/dialyzer_test.exs
@@ -14,6 +14,13 @@ defmodule Dialyxir.DialyzerTest do
     def run(_, _), do: {:error, "dialyzer failed"}
   end
 
+  defmodule ArgsCapture do
+    def run(args, _filterer) do
+      send(self(), {:dialyzer_args, args})
+      {:ok, {"time", [], ""}}
+    end
+  end
+
   setup do
     ansi_enabled = IO.ANSI.enabled?()
 
@@ -104,6 +111,119 @@ defmodule Dialyxir.DialyzerTest do
       assert expected_result_code == :error
       assert expected_exit_code == 1
       assert expected_messages == [[[], "dialyzer failed"]]
+    end
+  end
+
+  describe "incremental mode args" do
+    import Dialyzer, only: [dialyze: 3]
+
+    test "analysis_type :incremental is passed through to runner" do
+      args = [
+        {:analysis_type, :incremental},
+        {:init_plt, ~c"some.plt.incremental"},
+        {:output_plt, ~c"some.plt.incremental"},
+        {:files, [~c"some_file.beam"]},
+        {:warnings, [:unknown]},
+        {:format, []},
+        {:raw, nil},
+        {:list_unused_filters, nil},
+        {:ignore_exit_status, nil},
+        {:quiet_with_result, nil}
+      ]
+
+      dialyze(args, ArgsCapture, nil)
+
+      assert_received {:dialyzer_args, captured_args}
+      assert captured_args[:analysis_type] == :incremental
+    end
+
+    test "incremental mode uses separate PLT with output_plt" do
+      args = [
+        {:analysis_type, :incremental},
+        {:init_plt, ~c"deps.plt.incremental"},
+        {:output_plt, ~c"deps.plt.incremental"},
+        {:files, [~c"some_file.beam"]},
+        {:warnings, [:unknown]},
+        {:format, []},
+        {:raw, nil},
+        {:list_unused_filters, nil},
+        {:ignore_exit_status, nil},
+        {:quiet_with_result, nil}
+      ]
+
+      dialyze(args, ArgsCapture, nil)
+
+      assert_received {:dialyzer_args, captured_args}
+      assert captured_args[:init_plt] == ~c"deps.plt.incremental"
+      assert captured_args[:output_plt] == ~c"deps.plt.incremental"
+      refute Keyword.has_key?(captured_args, :check_plt)
+    end
+
+    test "analysis_type is not present when not specified" do
+      args = [
+        {:check_plt, false},
+        {:init_plt, ~c"some.plt"},
+        {:files, [~c"some_file.beam"]},
+        {:warnings, [:unknown]},
+        {:format, []},
+        {:raw, nil},
+        {:list_unused_filters, nil},
+        {:ignore_exit_status, nil},
+        {:quiet_with_result, nil}
+      ]
+
+      dialyze(args, ArgsCapture, nil)
+
+      assert_received {:dialyzer_args, captured_args}
+      refute Keyword.has_key?(captured_args, :analysis_type)
+      refute Keyword.has_key?(captured_args, :output_plt)
+    end
+  end
+
+  describe "filter_to_project_files/2" do
+    test "filters warnings to only project files" do
+      project_file = ~c"/app/lib/my_app.beam"
+      dep_file = ~c"/deps/some_dep/ebin/dep.beam"
+
+      warnings = [
+        {:warn_return_no_exit, {project_file, 10}, {:some_warning, []}},
+        {:warn_return_no_exit, {dep_file, 20}, {:some_warning, []}},
+        {:warn_matching, {project_file, 30}, {:pattern_match, []}}
+      ]
+
+      result = Dialyzer.filter_to_project_files(warnings, [project_file])
+
+      assert length(result) == 2
+
+      Enum.each(result, fn {_tag, {file, _line}, _warning} ->
+        assert file == project_file
+      end)
+    end
+
+    test "returns all warnings when project_files includes all files" do
+      file_a = ~c"/app/lib/a.beam"
+      file_b = ~c"/app/lib/b.beam"
+
+      warnings = [
+        {:warn_return_no_exit, {file_a, 10}, {:some_warning, []}},
+        {:warn_matching, {file_b, 20}, {:pattern_match, []}}
+      ]
+
+      result = Dialyzer.filter_to_project_files(warnings, [file_a, file_b])
+
+      assert length(result) == 2
+    end
+
+    test "returns empty list when no warnings match project files" do
+      dep_file = ~c"/deps/some_dep/ebin/dep.beam"
+
+      warnings = [
+        {:warn_return_no_exit, {dep_file, 10}, {:some_warning, []}}
+      ]
+
+      result = Dialyzer.filter_to_project_files(warnings, [~c"/app/lib/my_app.beam"])
+
+      assert result == []
     end
   end
 end

--- a/test/dialyxir/project_test.exs
+++ b/test/dialyxir/project_test.exs
@@ -205,4 +205,28 @@ defmodule Dialyxir.ProjectTest do
       assert Project.no_umbrella?()
     end)
   end
+
+  test "incremental_mode? returns true when explicitly enabled in config" do
+    in_project(:incremental_enabled, fn ->
+      assert Project.incremental_mode?()
+    end)
+  end
+
+  test "incremental_mode? returns false when explicitly disabled in config" do
+    in_project(:incremental_disabled, fn ->
+      refute Project.incremental_mode?()
+    end)
+  end
+
+  test "incremental_mode? defaults based on OTP version" do
+    in_project(:default_apps, fn ->
+      otp_major = :erlang.system_info(:otp_release) |> List.to_string() |> String.to_integer()
+
+      if otp_major >= 27 do
+        assert Project.incremental_mode?()
+      else
+        refute Project.incremental_mode?()
+      end
+    end)
+  end
 end

--- a/test/fixtures/incremental_disabled/mix.exs
+++ b/test/fixtures/incremental_disabled/mix.exs
@@ -1,0 +1,21 @@
+defmodule IncrementalDisabled.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :incremental_disabled,
+      prune_code_paths: false,
+      version: "0.1.0",
+      deps: deps(),
+      dialyzer: [incremental: false]
+    ]
+  end
+
+  def application do
+    [applications: [:logger]]
+  end
+
+  defp deps do
+    []
+  end
+end

--- a/test/fixtures/incremental_enabled/mix.exs
+++ b/test/fixtures/incremental_enabled/mix.exs
@@ -1,0 +1,21 @@
+defmodule IncrementalEnabled.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :incremental_enabled,
+      prune_code_paths: false,
+      version: "0.1.0",
+      deps: deps(),
+      dialyzer: [incremental: true]
+    ]
+  end
+
+  def application do
+    [applications: [:logger]]
+  end
+
+  defp deps do
+    []
+  end
+end

--- a/test/mix/tasks/dialyzer_test.exs
+++ b/test/mix/tasks/dialyzer_test.exs
@@ -103,4 +103,39 @@ defmodule Mix.Tasks.DialyzerTest do
                ":ignore_warnings opt specified in mix.exs: ignore_test.exs, but file is empty"
     end)
   end
+
+  test "incremental mode skips PLT checking" do
+    otp_major = :erlang.system_info(:otp_release) |> List.to_string() |> String.to_integer()
+
+    if otp_major >= 27 do
+      in_project(:default_apps, fn ->
+        fun = fn -> Mix.Tasks.Dialyzer.run(["--ignore-exit-status", "--no-compile", "--plt"]) end
+        output = capture_io(fun)
+
+        refute output =~ "Finding suitable PLTs"
+        refute output =~ "Checking PLT"
+      end)
+    end
+  end
+
+  test "--no-incremental flag disables incremental mode" do
+    otp_major = :erlang.system_info(:otp_release) |> List.to_string() |> String.to_integer()
+
+    if otp_major >= 27 do
+      in_project(:default_apps, fn ->
+        fun = fn ->
+          Mix.Tasks.Dialyzer.run([
+            "--no-incremental",
+            "--ignore-exit-status",
+            "--no-compile",
+            "--plt"
+          ])
+        end
+
+        output = capture_io(fun)
+
+        assert output =~ "Finding suitable PLTs"
+      end)
+    end
+  end
 end


### PR DESCRIPTION
Dialyzer's incremental mode (analysis_type: :incremental) is enabled by default on OTP 27+, skipping manual PLT management. Can be overridden via `dialyzer: [incremental: true/false]` in mix config or the --incremental/--no-incremental CLI flags.